### PR TITLE
Add an example for mirroring content to an outputContext during an exclusive session

### DIFF
--- a/mirroring.html
+++ b/mirroring.html
@@ -1,0 +1,216 @@
+<!doctype html>
+<!--
+Copyright 2017 The Chromium Authors. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file.
+-->
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <meta name='viewport' content='width=device-width, initial-scale=1, user-scalable=no'>
+    <meta name='mobile-web-app-capable' content='yes'>
+    <meta name='apple-mobile-web-app-capable' content='yes'>
+
+    <title>Mirroring</title>
+
+    <link href='css/common.css' rel='stylesheet'></link>
+
+    <script src='js/third-party/gl-matrix-min.js'></script>
+
+    <script src='js/third-party/wglu/wglu-program.js'></script>
+    <script src='js/third-party/wglu/wglu-stats.js'></script>
+    <script src='js/third-party/wglu/wglu-texture.js'></script>
+
+    <script src='js/webxr-button.js'></script>
+    <script src='js/webxr-scene.js'></script>
+    <script src='js/webxr-scene-cube-sea.js'></script>
+    <script src='js/webxr-samples-util.js'></script>
+  </head>
+  <body>
+    <header>
+      <details open>
+        <summary>Mirroring</summary>
+        <p>
+          This sample demonstrates how to present a simple WebGL scene to a
+          XRDevice while mirroring to a context. The scene is not rendered to
+          the page prior to XR presentation.
+        </p>
+      </details>
+    </header>
+    <main style='text-align: center;'>
+      <p>Click 'Enter XR' to see content</p>
+    </main>
+    <script>
+      (function () {
+      'use strict';
+
+      // XR globals.
+      let xrButton = null;
+      let xrFrameOfRef = null;
+
+      // WebGL scene globals.
+      let gl = null;
+      let scene = new WebXRSceneCubeSea();
+
+      // Checks to see if WebXR is available and, if so, queries a list of
+      // XRDevices that are connected to the system.
+      function initXR() {
+        // Adds a helper button to the page that indicates if any XRDevices are
+        // available and let's the user pick between them if there's multiple.
+        xrButton = new XRDeviceButton({
+          onRequestSession: onRequestSession,
+          onEndSession: onEndSession
+        });
+        document.querySelector('header').appendChild(xrButton.domElement);
+
+        // Is WebXR available on this UA?
+        if (navigator.xr) {
+          // Request a list of all the XR Devices connected to the system.
+          navigator.xr.requestDevice().then((device) => {
+            // If the device allows creation of exclusive sessions set it as the
+            // target of the 'Enter XR' button.
+            device.supportsSession({exclusive: true}).then(() => {
+              xrButton.setDevice(device);
+            });
+          });
+        }
+      }
+
+      // Called when the user selects a device to present to. In response we
+      // will request an exclusive session with a mirrored context from that
+      // device.
+      function onRequestSession(device) {
+        // In order to mirror an exclusive session, we must provide
+        // an XRPresentationContext, which indicates the canvas that will
+        // contain results of the session's rendering.
+        let mirrorCanvas = document.createElement('canvas');
+        let ctx = mirrorCanvas.getContext('xrpresent');
+        mirrorCanvas.setAttribute('id', 'output-canvas');
+
+        // Add the canvas to the document.
+        document.body.appendChild(mirrorCanvas);
+
+        device.requestSession({
+          exclusive: true,
+          outputContext: ctx
+        }).then(onSessionStarted);
+      }
+
+      // Called when we've successfully acquired a XRSession. In response we
+      // will set up the necessary session state and kick off the frame loop.
+      function onSessionStarted(session) {
+        // This informs the 'Enter XR' button that the session has started and
+        // that it should display 'Exit XR' instead.
+        xrButton.setSession(session);
+
+        // Listen for the sessions 'end' event so we can respond if the user
+        // or UA ends the session for any reason.
+        session.addEventListener('end', onSessionEnded);
+
+        // Create a WebGL context to render with, initialized to be compatible
+        // with the XRDisplay we're presenting to.
+        gl = XRSamplesUtil.initWebGLContext({
+          compatibleXRDevice: session.device
+        });
+
+        // Initialize the scene's WebGL content
+        scene.setWebGLContext(gl);
+
+        // Use the new WebGL context to create a XRWebGLLayer and set it as the
+        // sessions baseLayer. This allows any content rendered to the layer to
+        // be displayed on the XRDevice.
+        session.baseLayer = new XRWebGLLayer(session, gl);
+
+        // Set the mirroring context to be the same size as one eye on the
+        // layer context.
+        let outputCanvas = document.querySelector('#output-canvas');
+        outputCanvas.width = session.baseLayer.framebufferWidth / 2;
+        outputCanvas.height = session.baseLayer.framebufferHeight;
+
+        // Get a frame of reference, which is required for querying poses. In
+        // this case an 'eyeLevel' frame of reference means that all poses will
+        // be relative to the location where the XRDevice was first detected.
+        session.requestFrameOfReference('eyeLevel').then((frameOfRef) => {
+          xrFrameOfRef = frameOfRef;
+
+          // Inform the session that we're ready to begin drawing.
+          session.requestAnimationFrame(onXRFrame);
+        });
+      }
+
+      // Called when the user clicks the 'Exit XR' button. In response we end
+      // the session.
+      function onEndSession(session) {
+        session.end();
+      }
+
+      // Called either when the user has explicitly ended the session (like in
+      // onEndSession()) or when the UA has ended the session for any reason.
+      // At this point the session object is no longer usable and should be
+      // discarded.
+      function onSessionEnded(event) {
+        xrButton.setSession(null);
+
+        // In this simple case discard the WebGL context too, since we're not
+        // rendering anything else to the screen with it.
+        gl = null;
+
+        // Remove the injected mirroring canvas from the DOM.
+        document.body.removeChild(document.querySelector('#output-canvas'));
+      }
+
+      // Called every time the XRSession requests that a new frame be drawn.
+      function onXRFrame(t, frame) {
+        let session = frame.session;
+
+        // Per-frame scene setup. Nothing WebXR specific here.
+        scene.startFrame();
+
+        // Inform the session that we're ready for the next frame.
+        session.requestAnimationFrame(onXRFrame);
+
+        // Bind the WebGL layer's framebuffer, which is where any content to be
+        // displayed on the XRDevice must be rendered.
+        gl.bindFramebuffer(gl.FRAMEBUFFER, session.baseLayer.framebuffer);
+
+        // Clear the framebuffer
+        gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+
+        // Get the XRDevice pose relative to the Frame of Reference we created
+        // earlier.
+        let pose = frame.getDevicePose(xrFrameOfRef);
+
+        // Getting the pose may fail if, for example, tracking is lost. So we
+        // have to check to make sure that we got a valid pose before attempting
+        // to render with it. If not in this case we'll just leave the
+        // framebuffer cleared, so tracking loss means the scene will simply
+        // dissapear.
+        if (pose) {
+          // If we do have a valid pose, loop through each of the views reported
+          // by the frame and draw them into the corresponding viewport.
+          for (let view of frame.views) {
+            let viewport = view.getViewport(session.baseLayer);
+            gl.viewport(viewport.x, viewport.y,
+                        viewport.width, viewport.height);
+
+            // Draw this view of the scene. What happens in this function really
+            // isn't all that important. What is important is that it renders
+            // into the XRWebGLLayer's framebuffer, using the viewport into that
+            // framebuffer reported by the current view, and using the
+            // projection and view matricies from the current view and pose.
+            // We bound the framebuffer and viewport up above, and are passing
+            // in the appropriate matrices here to be used when rendering.
+            scene.draw(view.projectionMatrix, pose.getViewMatrix(view));
+          }
+        }
+
+        // Per-frame scene teardown. Nothing WebXR specific here.
+        scene.endFrame();
+      }
+
+      // Start the XR application.
+      initXR();
+      })();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
A bit ways off on testing this on a native desktop WebXR implementation, but exploring with this code on handling it via polyfilling on Firefox on Windows with a Vive.