### PR TITLE
Adding support for different left/right controller models

### DIFF
--- a/360-photos.html
+++ b/360-photos.html
@@ -111,7 +111,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
         renderer = new Renderer(gl);
         scene.setRenderer(renderer);
-        scene.inputRenderer.setControllerMesh(new Gltf2Node({url: 'media/gltf/controller/controller.gltf'}));
+        scene.inputRenderer.setControllerMesh(new Gltf2Node({url: 'media/gltf/controller/controller.gltf'}), 'right');
+        scene.inputRenderer.setControllerMesh(new Gltf2Node({url: 'media/gltf/controller/controller-left.gltf'}), 'left');
       }
 
       function onRequestSession() {

--- a/controller-state.html
+++ b/controller-state.html
@@ -278,7 +278,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         renderer = new Renderer(gl);
 
         scene.setRenderer(renderer);
-        scene.inputRenderer.setControllerMesh(new Gltf2Node({url: 'media/gltf/controller/controller.gltf'}));
+        scene.inputRenderer.setControllerMesh(new Gltf2Node({url: 'media/gltf/controller/controller.gltf'}), 'right');
+        scene.inputRenderer.setControllerMesh(new Gltf2Node({url: 'media/gltf/controller/controller-left.gltf'}), 'left');
 
         addFloorBox();
       }

--- a/framebuffer-scaling.html
+++ b/framebuffer-scaling.html
@@ -135,7 +135,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           renderer = new Renderer(gl);
 
           scene.setRenderer(renderer);
-          scene.inputRenderer.setControllerMesh(new Gltf2Node({url: 'media/gltf/controller/controller.gltf'}));
+          scene.inputRenderer.setControllerMesh(new Gltf2Node({url: 'media/gltf/controller/controller.gltf'}), 'right');
+          scene.inputRenderer.setControllerMesh(new Gltf2Node({url: 'media/gltf/controller/controller-left.gltf'}), 'left');
         }
 
         // This is the only meaningful change in this sample from xr-presentation.js.

--- a/input-selection.html
+++ b/input-selection.html
@@ -115,7 +115,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         renderer = new Renderer(gl);
 
         scene.setRenderer(renderer);
-        scene.inputRenderer.setControllerMesh(new Gltf2Node({url: 'media/gltf/controller/controller.gltf'}));
+        scene.inputRenderer.setControllerMesh(new Gltf2Node({url: 'media/gltf/controller/controller.gltf'}), 'right');
+        scene.inputRenderer.setControllerMesh(new Gltf2Node({url: 'media/gltf/controller/controller-left.gltf'}), 'left');
 
         // Create several boxes to use for hit testing.
         let boxBuilder = new BoxBuilder();

--- a/input-tracking.html
+++ b/input-tracking.html
@@ -118,8 +118,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
         scene.setRenderer(renderer);
 
-        // Loads a generic controller mesh.
-        scene.inputRenderer.setControllerMesh(new Gltf2Node({url: 'media/gltf/controller/controller.gltf'}));
+        // Loads a generic controller meshes.
+        scene.inputRenderer.setControllerMesh(new Gltf2Node({url: 'media/gltf/controller/controller.gltf'}), 'right');
+        scene.inputRenderer.setControllerMesh(new Gltf2Node({url: 'media/gltf/controller/controller-left.gltf'}), 'left');
       }
 
       function onRequestSession() {
@@ -207,7 +208,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             if (gripPose) {
               // If we have a grip pose use it to render a mesh showing the
               // position of the controller.
-              scene.inputRenderer.addController(gripPose.transform.matrix);
+              scene.inputRenderer.addController(gripPose.transform.matrix, inputSource.handedness);
             }
           }
           

--- a/js/render/nodes/input-renderer.js
+++ b/js/render/nodes/input-renderer.js
@@ -211,8 +211,7 @@ export class InputRenderer extends Node {
     this._maxInputElements = 32;
 
     this._controllers = [];
-    this._controllerNode = null;
-    this._controllerNodeHandedness = null;
+    this._controllerNodes = null;
     this._lasers = null;
     this._cursors = null;
 
@@ -223,8 +222,7 @@ export class InputRenderer extends Node {
 
   onRendererChanged(renderer) {
     this._controllers = [];
-    this._controllerNode = null;
-    this._controllerNodeHandedness = null;
+    this._controllerNodes = null;
     this._lasers = null;
     this._cursors = null;
 
@@ -234,23 +232,30 @@ export class InputRenderer extends Node {
   }
 
   setControllerMesh(controllerNode, handedness = 'right') {
-    this._controllerNode = controllerNode;
-    this._controllerNode.visible = false;
+    if (!this._controllerNodes) {
+      this._controllerNodes = {};
+    }
+    this._controllerNodes[handedness] = controllerNode;
+    this._controllerNodes[handedness].visible = false;
     // FIXME: Temporary fix to initialize for cloning.
-    this.addNode(this._controllerNode);
-    this._controllerNodeHandedness = handedness;
+    this.addNode(this._controllerNodes[handedness]);
   }
 
-  addController(gripMatrix) {
-    if (!this._controllerNode) {
+  addController(gripMatrix, handedness = 'right') {
+    let controllerNode = this._controllerNodes[handedness];
+    if (!controllerNode) {
+      // in the case if we don't have a node for correct handedness - fall back to the 'right' one.
+      controllerNode = this._controllerNodes['right'];
+      if (!controllerNode) {
         return;
+      }
     }
 
     let controller = null;
     if (this._activeControllers < this._controllers.length) {
       controller = this._controllers[this._activeControllers];
     } else {
-      controller = this._controllerNode.clone();
+      controller = controllerNode.clone();
       this.addNode(controller);
       this._controllers.push(controller);
     }

--- a/js/render/scenes/scene.js
+++ b/js/render/scenes/scene.js
@@ -140,7 +140,7 @@ export class Scene extends Node {
 
         // Any time that we have a grip matrix, we'll render a controller.
         if (gripPose) {
-          this.inputRenderer.addController(gripPose.transform.matrix);
+          this.inputRenderer.addController(gripPose.transform.matrix, inputSource.handedness);
         }
       }
       

--- a/js/webxr-sample-app.js
+++ b/js/webxr-sample-app.js
@@ -33,7 +33,8 @@ export class WebXRSampleApp {
       immersiveMode: options.immersiveMode || 'immersive-vr',
       referenceSpace: options.referenceSpace || 'local',
       defaultInputHandling: 'defaultInputHandling' in options ? options.defaultInputHandling : true,
-      controllerMesh: options.controllerMesh
+      controllerMesh: options.controllerMesh,
+      leftControllerMesh: options.leftControllerMesh
     };
 
     this.gl = null;
@@ -113,6 +114,9 @@ export class WebXRSampleApp {
 
       if (this.options.controllerMesh) {
         this.scene.inputRenderer.setControllerMesh(this.options.controllerMesh);
+      }
+      if (this.options.leftControllerMesh) {
+        this.scene.inputRenderer.setControllerMesh(this.options.leftControllerMesh, 'left');
       }
     }
   }

--- a/media/gltf/controller/controller-left.gltf
+++ b/media/gltf/controller/controller-left.gltf
@@ -1,0 +1,923 @@
+{
+    "accessors" : [
+        {
+            "bufferView" : 0, 
+            "componentType" : 5121, 
+            "count" : 228, 
+            "max" : [
+                135
+            ], 
+            "min" : [
+                0
+            ], 
+            "type" : "SCALAR"
+        }, 
+        {
+            "bufferView" : 1, 
+            "componentType" : 5126, 
+            "count" : 136, 
+            "max" : [
+                0.5582852363586426, 
+                0.2845833897590637, 
+                0.3353811502456665
+            ], 
+            "min" : [
+                -0.23979149758815765, 
+                -0.2354165017604828, 
+                -0.0747917890548706
+            ], 
+            "type" : "VEC3"
+        }, 
+        {
+            "bufferView" : 2, 
+            "componentType" : 5126, 
+            "count" : 136, 
+            "max" : [
+                1.0, 
+                1.0, 
+                1.0
+            ], 
+            "min" : [
+                -1.0, 
+                -1.0, 
+                -1.0
+            ], 
+            "type" : "VEC3"
+        }, 
+        {
+            "bufferView" : 3, 
+            "componentType" : 5126, 
+            "count" : 136, 
+            "max" : [
+                0.18914709985256195, 
+                1.0885394290089607
+            ], 
+            "min" : [
+                -0.1891472041606903, 
+                0.8391132950782776
+            ], 
+            "type" : "VEC2"
+        }, 
+        {
+            "bufferView" : 4, 
+            "componentType" : 5121, 
+            "count" : 288, 
+            "max" : [
+                191
+            ], 
+            "min" : [
+                0
+            ], 
+            "type" : "SCALAR"
+        }, 
+        {
+            "bufferView" : 5, 
+            "componentType" : 5126, 
+            "count" : 192, 
+            "max" : [
+                0.040208641439676285, 
+                0.07458347082138062, 
+                0.08520817756652832
+            ], 
+            "min" : [
+                -0.19979159533977509, 
+                -0.21541659533977509, 
+                -0.15479199588298798
+            ], 
+            "type" : "VEC3"
+        }, 
+        {
+            "bufferView" : 6, 
+            "componentType" : 5126, 
+            "count" : 192, 
+            "max" : [
+                1.0, 
+                1.0, 
+                1.0
+            ], 
+            "min" : [
+                -1.0, 
+                -1.0, 
+                -1.0
+            ], 
+            "type" : "VEC3"
+        }, 
+        {
+            "bufferView" : 7, 
+            "componentType" : 5126, 
+            "count" : 192, 
+            "max" : [
+                0.16224870085716248, 
+                1.0807880088686943
+            ], 
+            "min" : [
+                -0.16224870085716248, 
+                0.8357419073581696
+            ], 
+            "type" : "VEC2"
+        }, 
+        {
+            "bufferView" : 8, 
+            "componentType" : 5121, 
+            "count" : 72, 
+            "max" : [
+                47
+            ], 
+            "min" : [
+                0
+            ], 
+            "type" : "SCALAR"
+        }, 
+        {
+            "bufferView" : 9, 
+            "componentType" : 5126, 
+            "count" : 48, 
+            "max" : [
+                0.11020849645137787, 
+                0.2645834982395172, 
+                0.08520817756652832
+            ], 
+            "min" : [
+                -0.19979159533977509, 
+                0.05458331108093262, 
+                -0.09479188919067383
+            ], 
+            "type" : "VEC3"
+        }, 
+        {
+            "bufferView" : 10, 
+            "componentType" : 5126, 
+            "count" : 48, 
+            "max" : [
+                1.0, 
+                1.0, 
+                1.0
+            ], 
+            "min" : [
+                -1.0, 
+                -1.0, 
+                -1.0
+            ], 
+            "type" : "VEC3"
+        }, 
+        {
+            "bufferView" : 11, 
+            "componentType" : 5126, 
+            "count" : 48, 
+            "max" : [
+                0.14847490191459656, 
+                1.089869037270546
+            ], 
+            "min" : [
+                -0.14847490191459656, 
+                0.8485292047262192
+            ], 
+            "type" : "VEC2"
+        }, 
+        {
+            "bufferView" : 12, 
+            "componentType" : 5121, 
+            "count" : 132, 
+            "max" : [
+                71
+            ], 
+            "min" : [
+                0
+            ], 
+            "type" : "SCALAR"
+        }, 
+        {
+            "bufferView" : 13, 
+            "componentType" : 5126, 
+            "count" : 72, 
+            "max" : [
+                -0.049791570752859116, 
+                0.04458343982696533, 
+                0.06520813703536987
+            ], 
+            "min" : [
+                -0.08979153633117676, 
+                0.004583477973937988, 
+                0.025208119302988052
+            ], 
+            "type" : "VEC3"
+        }, 
+        {
+            "bufferView" : 14, 
+            "componentType" : 5126, 
+            "count" : 72, 
+            "max" : [
+                1.0, 
+                0.9659108519554138, 
+                0.9659108519554138
+            ], 
+            "min" : [
+                -1.0, 
+                -0.9659108519554138, 
+                -0.9659108519554138
+            ], 
+            "type" : "VEC3"
+        }, 
+        {
+            "bufferView" : 15, 
+            "componentType" : 5126, 
+            "count" : 72, 
+            "max" : [
+                0.18237340450286865, 
+                1.112764097750187
+            ], 
+            "min" : [
+                -0.18237340450286865, 
+                0.8561871945858002
+            ], 
+            "type" : "VEC2"
+        }, 
+        {
+            "bufferView" : 16, 
+            "componentType" : 5121, 
+            "count" : 156, 
+            "max" : [
+                107
+            ], 
+            "min" : [
+                0
+            ], 
+            "type" : "SCALAR"
+        }, 
+        {
+            "bufferView" : 17, 
+            "componentType" : 5126, 
+            "count" : 108, 
+            "max" : [
+                0.16020849347114563, 
+                0.2645834982395172, 
+                0.08520817756652832
+            ], 
+            "min" : [
+                -0.15979160368442535, 
+                -0.21541659533977509, 
+                0.005208135116845369
+            ], 
+            "type" : "VEC3"
+        }, 
+        {
+            "bufferView" : 18, 
+            "componentType" : 5126, 
+            "count" : 108, 
+            "max" : [
+                1.0, 
+                1.0, 
+                1.0
+            ], 
+            "min" : [
+                -1.0, 
+                -1.0, 
+                -1.0
+            ], 
+            "type" : "VEC3"
+        }, 
+        {
+            "bufferView" : 19, 
+            "componentType" : 5126, 
+            "count" : 108, 
+            "max" : [
+                0.16090330481529236, 
+                1.0861021131277084
+            ], 
+            "min" : [
+                -0.18715770542621613, 
+                0.8409731984138489
+            ], 
+            "type" : "VEC2"
+        }, 
+        {
+            "bufferView" : 20, 
+            "componentType" : 5121, 
+            "count" : 36, 
+            "max" : [
+                23
+            ], 
+            "min" : [
+                0
+            ], 
+            "type" : "SCALAR"
+        }, 
+        {
+            "bufferView" : 21, 
+            "componentType" : 5126, 
+            "count" : 24, 
+            "max" : [
+                -0.03979146108031273, 
+                0.20458349585533142, 
+                -0.07479190826416016
+            ], 
+            "min" : [
+                -0.11979140341281891, 
+                0.124583400785923, 
+                -0.09479188919067383
+            ], 
+            "type" : "VEC3"
+        }, 
+        {
+            "bufferView" : 22, 
+            "componentType" : 5126, 
+            "count" : 24, 
+            "max" : [
+                1.0, 
+                1.0, 
+                1.0
+            ], 
+            "min" : [
+                -1.0, 
+                -1.0, 
+                -1.0
+            ], 
+            "type" : "VEC3"
+        }, 
+        {
+            "bufferView" : 23, 
+            "componentType" : 5126, 
+            "count" : 24, 
+            "max" : [
+                0.1538413017988205, 
+                1.0803171172738075
+            ], 
+            "min" : [
+                -0.15384159982204437, 
+                0.8525978028774261
+            ], 
+            "type" : "VEC2"
+        }, 
+        {
+            "bufferView" : 24, 
+            "componentType" : 5121, 
+            "count" : 36, 
+            "max" : [
+                23
+            ], 
+            "min" : [
+                0
+            ], 
+            "type" : "SCALAR"
+        }, 
+        {
+            "bufferView" : 25, 
+            "componentType" : 5126, 
+            "count" : 24, 
+            "max" : [
+                0.20020850002765656, 
+                -0.00541651202365756, 
+                -0.07479190826416016
+            ], 
+            "min" : [
+                0.1202085018157959, 
+                -0.08541644364595413, 
+                -0.09479188919067383
+            ], 
+            "type" : "VEC3"
+        }, 
+        {
+            "bufferView" : 26, 
+            "componentType" : 5126, 
+            "count" : 24, 
+            "max" : [
+                1.0, 
+                1.0, 
+                1.0
+            ], 
+            "min" : [
+                -1.0, 
+                -1.0, 
+                -1.0
+            ], 
+            "type" : "VEC3"
+        }, 
+        {
+            "bufferView" : 27, 
+            "componentType" : 5126, 
+            "count" : 24, 
+            "max" : [
+                0.14310850203037262, 
+                1.0506522618234158
+            ], 
+            "min" : [
+                -0.14310820400714874, 
+                0.8403917998075485
+            ], 
+            "type" : "VEC2"
+        }, 
+        {
+            "bufferView" : 28, 
+            "componentType" : 5121, 
+            "count" : 72, 
+            "max" : [
+                47
+            ], 
+            "min" : [
+                0
+            ], 
+            "type" : "SCALAR"
+        }, 
+        {
+            "bufferView" : 29, 
+            "componentType" : 5126, 
+            "count" : 48, 
+            "max" : [
+                0.401400089263916, 
+                0.12203703820705414, 
+                0.2585950493812561
+            ], 
+            "min" : [
+                -0.17979149520397186, 
+                -0.05541646108031273, 
+                0.10520809888839722
+            ], 
+            "type" : "VEC3"
+        }, 
+        {
+            "bufferView" : 30, 
+            "componentType" : 5126, 
+            "count" : 48, 
+            "max" : [
+                1.0, 
+                1.0, 
+                1.0
+            ], 
+            "min" : [
+                -1.0, 
+                -1.0, 
+                -1.0
+            ], 
+            "type" : "VEC3"
+        }, 
+        {
+            "bufferView" : 31, 
+            "componentType" : 5126, 
+            "count" : 48, 
+            "max" : [
+                0.16102929413318634, 
+                1.0819315612316132
+            ], 
+            "min" : [
+                -0.16102929413318634, 
+                0.8584104031324387
+            ], 
+            "type" : "VEC2"
+        }
+    ], 
+    "asset" : {
+        "generator" : "Khronos Blender glTF 2.0 exporter", 
+        "version" : "2.0"
+    }, 
+    "bufferViews" : [
+        {
+            "buffer" : 0, 
+            "byteLength" : 228, 
+            "byteOffset" : 0, 
+            "target" : 34963
+        }, 
+        {
+            "buffer" : 0, 
+            "byteLength" : 1632, 
+            "byteOffset" : 228, 
+            "target" : 34962
+        }, 
+        {
+            "buffer" : 0, 
+            "byteLength" : 1632, 
+            "byteOffset" : 1860, 
+            "target" : 34962
+        }, 
+        {
+            "buffer" : 0, 
+            "byteLength" : 1088, 
+            "byteOffset" : 3492, 
+            "target" : 34962
+        }, 
+        {
+            "buffer" : 0, 
+            "byteLength" : 288, 
+            "byteOffset" : 4580, 
+            "target" : 34963
+        }, 
+        {
+            "buffer" : 0, 
+            "byteLength" : 2304, 
+            "byteOffset" : 4868, 
+            "target" : 34962
+        }, 
+        {
+            "buffer" : 0, 
+            "byteLength" : 2304, 
+            "byteOffset" : 7172, 
+            "target" : 34962
+        }, 
+        {
+            "buffer" : 0, 
+            "byteLength" : 1536, 
+            "byteOffset" : 9476, 
+            "target" : 34962
+        }, 
+        {
+            "buffer" : 0, 
+            "byteLength" : 72, 
+            "byteOffset" : 11012, 
+            "target" : 34963
+        }, 
+        {
+            "buffer" : 0, 
+            "byteLength" : 576, 
+            "byteOffset" : 11084, 
+            "target" : 34962
+        }, 
+        {
+            "buffer" : 0, 
+            "byteLength" : 576, 
+            "byteOffset" : 11660, 
+            "target" : 34962
+        }, 
+        {
+            "buffer" : 0, 
+            "byteLength" : 384, 
+            "byteOffset" : 12236, 
+            "target" : 34962
+        }, 
+        {
+            "buffer" : 0, 
+            "byteLength" : 132, 
+            "byteOffset" : 12620, 
+            "target" : 34963
+        }, 
+        {
+            "buffer" : 0, 
+            "byteLength" : 864, 
+            "byteOffset" : 12752, 
+            "target" : 34962
+        }, 
+        {
+            "buffer" : 0, 
+            "byteLength" : 864, 
+            "byteOffset" : 13616, 
+            "target" : 34962
+        }, 
+        {
+            "buffer" : 0, 
+            "byteLength" : 576, 
+            "byteOffset" : 14480, 
+            "target" : 34962
+        }, 
+        {
+            "buffer" : 0, 
+            "byteLength" : 156, 
+            "byteOffset" : 15056, 
+            "target" : 34963
+        }, 
+        {
+            "buffer" : 0, 
+            "byteLength" : 1296, 
+            "byteOffset" : 15212, 
+            "target" : 34962
+        }, 
+        {
+            "buffer" : 0, 
+            "byteLength" : 1296, 
+            "byteOffset" : 16508, 
+            "target" : 34962
+        }, 
+        {
+            "buffer" : 0, 
+            "byteLength" : 864, 
+            "byteOffset" : 17804, 
+            "target" : 34962
+        }, 
+        {
+            "buffer" : 0, 
+            "byteLength" : 36, 
+            "byteOffset" : 18668, 
+            "target" : 34963
+        }, 
+        {
+            "buffer" : 0, 
+            "byteLength" : 288, 
+            "byteOffset" : 18704, 
+            "target" : 34962
+        }, 
+        {
+            "buffer" : 0, 
+            "byteLength" : 288, 
+            "byteOffset" : 18992, 
+            "target" : 34962
+        }, 
+        {
+            "buffer" : 0, 
+            "byteLength" : 192, 
+            "byteOffset" : 19280, 
+            "target" : 34962
+        }, 
+        {
+            "buffer" : 0, 
+            "byteLength" : 36, 
+            "byteOffset" : 19472, 
+            "target" : 34963
+        }, 
+        {
+            "buffer" : 0, 
+            "byteLength" : 288, 
+            "byteOffset" : 19508, 
+            "target" : 34962
+        }, 
+        {
+            "buffer" : 0, 
+            "byteLength" : 288, 
+            "byteOffset" : 19796, 
+            "target" : 34962
+        }, 
+        {
+            "buffer" : 0, 
+            "byteLength" : 192, 
+            "byteOffset" : 20084, 
+            "target" : 34962
+        }, 
+        {
+            "buffer" : 0, 
+            "byteLength" : 72, 
+            "byteOffset" : 20276, 
+            "target" : 34963
+        }, 
+        {
+            "buffer" : 0, 
+            "byteLength" : 576, 
+            "byteOffset" : 20348, 
+            "target" : 34962
+        }, 
+        {
+            "buffer" : 0, 
+            "byteLength" : 576, 
+            "byteOffset" : 20924, 
+            "target" : 34962
+        }, 
+        {
+            "buffer" : 0, 
+            "byteLength" : 384, 
+            "byteOffset" : 21500, 
+            "target" : 34962
+        }
+    ], 
+    "buffers" : [
+        {
+            "byteLength" : 21884, 
+            "uri" : "controller.bin"
+        }
+    ], 
+    "materials" : [
+        {
+            "name" : "mat12", 
+            "doubleSided" : true,
+            "pbrMetallicRoughness" : {
+                "baseColorFactor" : [
+                    1.0, 
+                    0.9200000166893005, 
+                    0.23000000417232513, 
+                    1.0
+                ], 
+                "metallicFactor" : 0.0
+            }
+        }, 
+        {
+            "name" : "mat15", 
+            "doubleSided" : true,
+            "pbrMetallicRoughness" : {
+                "baseColorFactor" : [
+                    0.8100000023841858, 
+                    0.8500000238418579, 
+                    0.8600000143051147, 
+                    1.0
+                ], 
+                "metallicFactor" : 0.0
+            }
+        }, 
+        {
+            "name" : "mat16", 
+            "doubleSided" : true,
+            "pbrMetallicRoughness" : {
+                "baseColorFactor" : [
+                    0.4699999988079071, 
+                    0.5600000023841858, 
+                    0.6100000143051147, 
+                    1.0
+                ], 
+                "metallicFactor" : 0.0
+            }
+        }, 
+        {
+            "name" : "mat17", 
+            "doubleSided" : true,
+            "pbrMetallicRoughness" : {
+                "baseColorFactor" : [
+                    0.27000001072883606, 
+                    0.3499999940395355, 
+                    0.38999998569488525, 
+                    1.0
+                ], 
+                "metallicFactor" : 0.0
+            }
+        }, 
+        {
+            "name" : "mat22", 
+            "doubleSided" : true,
+            "pbrMetallicRoughness" : {
+                "baseColorFactor" : [
+                    0.6200000047683716, 
+                    0.6200000047683716, 
+                    0.6200000047683716, 
+                    1.0
+                ], 
+                "metallicFactor" : 0.0
+            }
+        }, 
+        {
+            "name" : "mat5", 
+            "doubleSided" : true,
+            "pbrMetallicRoughness" : {
+                "baseColorFactor" : [
+                    0.009999999776482582, 
+                    0.6100000143051147, 
+                    0.8999999761581421, 
+                    1.0
+                ], 
+                "metallicFactor" : 0.0
+            }
+        }, 
+        {
+            "name" : "mat8", 
+            "doubleSided" : true,
+            "pbrMetallicRoughness" : {
+                "baseColorFactor" : [
+                    0.9599999785423279, 
+                    0.25999999046325684, 
+                    0.20999999344348907, 
+                    1.0
+                ], 
+                "metallicFactor" : 0.0
+            }
+        }, 
+        {
+            "name" : "mat9", 
+            "doubleSided" : true,
+            "pbrMetallicRoughness" : {
+                "baseColorFactor" : [
+                    0.550000011920929, 
+                    0.7599999904632568, 
+                    0.28999999165534973, 
+                    1.0
+                ], 
+                "metallicFactor" : 0.0
+            }
+        }
+    ], 
+    "meshes" : [
+        {
+            "name" : "mesh340565441", 
+            "primitives" : [
+                {
+                    "attributes" : {
+                        "NORMAL" : 2, 
+                        "POSITION" : 1, 
+                        "TEXCOORD_0" : 3
+                    }, 
+                    "indices" : 0, 
+                    "material" : 2
+                }, 
+                {
+                    "attributes" : {
+                        "NORMAL" : 6, 
+                        "POSITION" : 5, 
+                        "TEXCOORD_0" : 7
+                    }, 
+                    "indices" : 4, 
+                    "material" : 5
+                }, 
+                {
+                    "attributes" : {
+                        "NORMAL" : 10, 
+                        "POSITION" : 9, 
+                        "TEXCOORD_0" : 11
+                    }, 
+                    "indices" : 8, 
+                    "material" : 6
+                }, 
+                {
+                    "attributes" : {
+                        "NORMAL" : 14, 
+                        "POSITION" : 13, 
+                        "TEXCOORD_0" : 15
+                    }, 
+                    "indices" : 12, 
+                    "material" : 0
+                }, 
+                {
+                    "attributes" : {
+                        "NORMAL" : 18, 
+                        "POSITION" : 17, 
+                        "TEXCOORD_0" : 19
+                    }, 
+                    "indices" : 16, 
+                    "material" : 1
+                }, 
+                {
+                    "attributes" : {
+                        "NORMAL" : 22, 
+                        "POSITION" : 21, 
+                        "TEXCOORD_0" : 23
+                    }, 
+                    "indices" : 20, 
+                    "material" : 7
+                }, 
+                {
+                    "attributes" : {
+                        "NORMAL" : 26, 
+                        "POSITION" : 25, 
+                        "TEXCOORD_0" : 27
+                    }, 
+                    "indices" : 24, 
+                    "material" : 4
+                }, 
+                {
+                    "attributes" : {
+                        "NORMAL" : 30, 
+                        "POSITION" : 29, 
+                        "TEXCOORD_0" : 31
+                    }, 
+                    "indices" : 28, 
+                    "material" : 3
+                }
+            ]
+        }
+    ], 
+    "nodes" : [
+        {
+            "name" : "Camera", 
+            "rotation" : [
+                0.483536034822464, 
+                0.33687159419059753, 
+                -0.20870360732078552, 
+                0.7804827094078064
+            ], 
+            "translation" : [
+                7.481131553649902, 
+                5.34366512298584, 
+                6.5076398849487305
+            ]
+        }, 
+        {
+            "name" : "Lamp", 
+            "rotation" : [
+                0.16907575726509094, 
+                0.7558802962303162, 
+                -0.27217137813568115, 
+                0.570947527885437
+            ], 
+            "scale" : [
+                1.0, 
+                1.0, 
+                0.9999999403953552
+            ], 
+            "translation" : [
+                4.076245307922363, 
+                5.903861999511719, 
+                -1.0054539442062378
+            ]
+        }, 
+        {
+            "mesh" : 0, 
+            "name" : "mesh340565441", 
+            "rotation" : [
+                0.27535855770111084, 
+                -0.2625792920589447, 
+                0.6512892842292786, 
+                0.6565455794334412
+            ], 
+            "scale" : [
+                0.15000000596046448, 
+                -0.15000000596046448, 
+                0.15000000596046448
+            ], 
+            "translation" : [
+                0.002365116961300373, 
+                -0.024121612310409546, 
+                -0.046547919511795044
+            ]
+        }
+    ], 
+    "scene" : 0, 
+    "scenes" : [
+        {
+            "name" : "Scene", 
+            "nodes" : [
+                2, 
+                1, 
+                0
+            ]
+        }
+    ]
+}

--- a/positional-audio.html
+++ b/positional-audio.html
@@ -320,7 +320,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
         renderer = new Renderer(gl);
         scene.setRenderer(renderer);
-        scene.inputRenderer.setControllerMesh(new Gltf2Node({url: 'media/gltf/controller/controller.gltf'}));
+        scene.inputRenderer.setControllerMesh(new Gltf2Node({url: 'media/gltf/controller/controller.gltf'}), 'right');
+        scene.inputRenderer.setControllerMesh(new Gltf2Node({url: 'media/gltf/controller/controller-left.gltf'}), 'left');
       }
 
       function onRequestSession() {

--- a/spectator-mode.html
+++ b/spectator-mode.html
@@ -126,7 +126,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
         renderer = new Renderer(gl);
         scene.setRenderer(renderer);
-        scene.inputRenderer.setControllerMesh(new Gltf2Node({url: 'media/gltf/controller/controller.gltf'}));
+        scene.inputRenderer.setControllerMesh(new Gltf2Node({url: 'media/gltf/controller/controller.gltf'}), 'right');
+        scene.inputRenderer.setControllerMesh(new Gltf2Node({url: 'media/gltf/controller/controller-left.gltf'}), 'left');
       }
 
       function onRequestSession() {

--- a/stereo-video.html
+++ b/stereo-video.html
@@ -169,7 +169,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
         renderer = new Renderer(gl);
         scene.setRenderer(renderer);
-        scene.inputRenderer.setControllerMesh(new Gltf2Node({url: 'media/gltf/controller/controller.gltf'}));
+        scene.inputRenderer.setControllerMesh(new Gltf2Node({url: 'media/gltf/controller/controller.gltf'}), 'right');
+        scene.inputRenderer.setControllerMesh(new Gltf2Node({url: 'media/gltf/controller/controller-left.gltf'}), 'left');
       }
 
       function onRequestSession() {

--- a/teleportation.html
+++ b/teleportation.html
@@ -170,7 +170,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         renderer = new Renderer(gl);
 
         scene.setRenderer(renderer);
-        scene.inputRenderer.setControllerMesh(new Gltf2Node({url: 'media/gltf/controller/controller.gltf'}));
+        scene.inputRenderer.setControllerMesh(new Gltf2Node({url: 'media/gltf/controller/controller.gltf'}), 'right');
+        scene.inputRenderer.setControllerMesh(new Gltf2Node({url: 'media/gltf/controller/controller-left.gltf'}), 'left');
 
         // Create several boxes to use for hit testing.
         addBox(-1.0, 1.6, -1.3, 1.0, 0.0, 0.0, boxes);

--- a/tests/cube-sea.html
+++ b/tests/cube-sea.html
@@ -294,7 +294,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
         renderer = new Renderer(gl);
         scene.setRenderer(renderer);
-        scene.inputRenderer.setControllerMesh(new Gltf2Node({url: '../media/gltf/controller/controller.gltf'}));
+        scene.inputRenderer.setControllerMesh(new Gltf2Node({url: '../media/gltf/controller/controller.gltf'}), 'right');
+        scene.inputRenderer.setControllerMesh(new Gltf2Node({url: '../media/gltf/controller/controller-left.gltf'}), 'left');
       }
 
       function onRequestSession() {

--- a/tests/offscreen-canvas.html
+++ b/tests/offscreen-canvas.html
@@ -74,7 +74,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       };
 
       let app = new CustomWebXRSampleApp({
-        controllerMesh: new Gltf2Node({url: '../media/gltf/controller/controller.gltf'})
+        controllerMesh: new Gltf2Node({url: '../media/gltf/controller/controller.gltf'}),
+        leftControllerMesh: new Gltf2Node({url: '../media/gltf/controller/controller-left.gltf'})
       });
       document.querySelector('header').appendChild(app.xrButton.domElement);
 

--- a/tests/permission-request.html
+++ b/tests/permission-request.html
@@ -70,7 +70,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       // WebXR sample app setup
       let app = new WebXRSampleApp({
         referenceSpace: 'local-floor',
-        controllerMesh: new Gltf2Node({url: '../media/gltf/controller/controller.gltf'})
+        controllerMesh: new Gltf2Node({url: '../media/gltf/controller/controller.gltf'}),
+        leftControllerMesh: new Gltf2Node({url: '../media/gltf/controller/controller-left.gltf'})
       });
       document.querySelector('header').appendChild(app.xrButton.domElement);
 

--- a/tests/pointer-painter.html
+++ b/tests/pointer-painter.html
@@ -102,8 +102,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
         onRendererInit() {
           super.onRendererInit();
-
-          this.scene.inputRenderer.setControllerMesh(new Gltf2Node({url: '../media/gltf/controller/controller.gltf'}));
         }
 
         onXRFrame(time, frame, refSpace) {
@@ -118,7 +116,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             if (inputSource.gripSpace) {
               let gripPose = frame.getPose(inputSource.gripSpace, refSpace);
               if (gripPose) {
-                this.scene.inputRenderer.addController(gripPose.transform.matrix);
+                this.scene.inputRenderer.addController(gripPose.transform.matrix, inputSource.handedness);
               }
             }
           }
@@ -132,7 +130,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       let app = new CustomWebXRSampleApp({
         referenceSpace: 'local-floor',
         defaultInputHandling: false,
-        controllerMesh: new Gltf2Node({url: '../media/gltf/controller/controller.gltf'})
+        controllerMesh: new Gltf2Node({url: '../media/gltf/controller/controller.gltf'}),
+        leftControllerMesh: new Gltf2Node({url: '../media/gltf/controller/controller-left.gltf'})
       });
       document.querySelector('header').appendChild(app.xrButton.domElement);
 

--- a/tests/sponza.html
+++ b/tests/sponza.html
@@ -71,7 +71,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
       let app = new CustomWebXRSampleApp({
         referenceSpace: 'local-floor',
-        controllerMesh: new Gltf2Node({url: '../media/gltf/controller/controller.gltf'})
+        controllerMesh: new Gltf2Node({url: '../media/gltf/controller/controller.gltf'}),
+        leftControllerMesh: new Gltf2Node({url: '../media/gltf/controller/controller-left.gltf'})
       });
       document.querySelector('header').appendChild(app.xrButton.domElement);
 


### PR DESCRIPTION
I found out that there is only one model for the controller and that neither of the examples or tests actually uses input source's handedness. This PR adds a model for the left controller (which is mirrored right one; I also had to make materials double sided since normals got inverted and this was the easiest way to fix it).