### PR TITLE
cancel rAF for inline when immersive-ar starts

### DIFF
--- a/proposals/immersive-ar-session.html
+++ b/proposals/immersive-ar-session.html
@@ -175,14 +175,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
       function onEndSession(session) {
         session.end();
-
-        // if this was immersive session stopping, restart the inlineSession
-        if (session != inlineSession) {
-          rAFHandle = inlineSession.requestAnimationFrame(onXRFrame);
-        } else {
-          console.warn("inline session unexpectedly ended");
-          inlineSession = null;
-        }
       }
 
       function onSessionEnded(event) {
@@ -190,6 +182,12 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           xrButton.setSession(null);
           // Turn the background back on when we go back to the inlive view.
           skybox.visible = true;
+
+          // if this was immersive session stopping, restart the inlineSession
+          rAFHandle = inlineSession.requestAnimationFrame(onXRFrame);
+        } else {
+          console.warn("inline session unexpectedly ended");
+          inlineSession = null;
         }
       }
 

--- a/proposals/immersive-ar-session.html
+++ b/proposals/immersive-ar-session.html
@@ -69,6 +69,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       let xrButton = null;
       let xrImmersiveRefSpace = null;
       let inlineViewerHelper = null;
+      let rAFHandle = null;
 
       // WebGL scene globals.
       let gl = null;
@@ -113,6 +114,12 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             .then((session) => {
               xrButton.setSession(session);
               session.isImmersive = true;
+
+              if (rAFHandle) {
+                xrButton.session.cancelAnimationFrame(rAFHandle);
+                rAFHandle = null
+              }
+
               onSessionStarted(session);
             });
       }
@@ -158,7 +165,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           } else {
             inlineViewerHelper = new InlineViewerHelper(gl.canvas, refSpace);
           }
-          session.requestAnimationFrame(onXRFrame);
+          rAFHandle = session.requestAnimationFrame(onXRFrame);
         });
       }
 
@@ -184,7 +191,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
         scene.startFrame();
 
-        session.requestAnimationFrame(onXRFrame);
+        rAFHandle = session.requestAnimationFrame(onXRFrame);
 
         scene.drawXRFrame(frame, pose);
 

--- a/proposals/immersive-ar-session.html
+++ b/proposals/immersive-ar-session.html
@@ -70,6 +70,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       let xrImmersiveRefSpace = null;
       let inlineViewerHelper = null;
       let rAFHandle = null;
+      let inlineSession = null;
 
       // WebGL scene globals.
       let gl = null;
@@ -115,11 +116,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
               xrButton.setSession(session);
               session.isImmersive = true;
 
-              if (rAFHandle) {
-                xrButton.session.cancelAnimationFrame(rAFHandle);
-                rAFHandle = null
-              }
-
               onSessionStarted(session);
             });
       }
@@ -152,6 +148,14 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           // When in 'immersive-ar' mode don't draw an opaque background because
           // we want the real world to show through.
           skybox.visible = false;
+
+          // stop the inline session rendering
+          if (inlineSession && rAFHandle) {
+            inlineSession.cancelAnimationFrame(rAFHandle);
+            rAFHandle = null;
+          }
+        } else {
+          inlineSession = session;
         }
 
         initGL();
@@ -171,6 +175,14 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
       function onEndSession(session) {
         session.end();
+
+        // if this was immersive session stopping, restart the inlineSession
+        if (session != inlineSession) {
+          rAFHandle = inlineSession.requestAnimationFrame(onXRFrame);
+        } else {
+          console.warn("inline session unexpectedly ended");
+          inlineSession = null;
+        }
       }
 
       function onSessionEnded(event) {


### PR DESCRIPTION
The immersive-ar-session sample starts with an inline session and then adds another session for immersive-ar.  It starts a rAF loop for each, resulting in double rendering.

The native implementation _may_ implicitely cancel the rAF on the inline session, but that doesn't technically seem right.  The webxr-polyfill does not do this.  

This update cancels the inline rAF before starting the immersive rAF.