### PR TITLE
Add Plane Detection API sample

### DIFF
--- a/js/hit-test.js
+++ b/js/hit-test.js
@@ -1,0 +1,311 @@
+// Copyright 2021 The Immersive Web Community Group
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// Negates a vector. All componenes except |w| are negated.
+let neg = function(vector) {
+  return {x : -vector.x, y : -vector.y, z : -vector.z, w : vector.w};
+}
+
+// Subtracts 2 vectors.
+let sub = function(lhs, rhs) {
+  if(!((lhs.w == 1 && rhs.w == 1) || (lhs.w == 1 && rhs.w == 0) || (lhs.w == 0 && rhs.w == 0)))
+    console.error("only point - point, point - line or line - line subtraction is allowed");
+  return {x : lhs.x - rhs.x, y : lhs.y - rhs.y, z : lhs.z - rhs.z, w : lhs.w - rhs.w};
+}
+
+// Subtracts 2 vectors.
+let add = function(lhs, rhs) {
+  if(!((lhs.w == 0 && rhs.w == 1) || (lhs.w == 1 && rhs.w == 0)))
+    console.error("only line + point or point + line addition is allowed");
+
+  return {x : lhs.x + rhs.x, y : lhs.y + rhs.y, z : lhs.z + rhs.z, w : lhs.w + rhs.w};
+}
+
+// Scales a vector by a scalar. All components except |w| are scaled.
+let mul = function(vector, scalar) {
+  return {x : vector.x * scalar, y : vector.y * scalar, z : vector.z * scalar, w : vector.w};
+}
+
+// |matrix| - Float32Array, |input| - point-like dict (must have x, y, z, w)
+export function transform_point_by_matrix (matrix, input) {
+  return {
+    x : matrix[0] * input.x + matrix[4] * input.y + matrix[8] * input.z + matrix[12] * input.w,
+    y : matrix[1] * input.x + matrix[5] * input.y + matrix[9] * input.z + matrix[13] * input.w,
+    z : matrix[2] * input.x + matrix[6] * input.y + matrix[10] * input.z + matrix[14] * input.w,
+    w : matrix[3] * input.x + matrix[7] * input.y + matrix[11] * input.z + matrix[15] * input.w,
+  };
+}
+
+// |point| - point-like dict (must have x, y, z, w)
+let normalize_perspective = function(point) {
+  if(point.w == 0 || point.w == 1) return point;
+
+  return {
+    x : point.x / point.w,
+    y : point.y / point.w,
+    z : point.z / point.w,
+    w : 1
+  };
+}
+
+let dotProduct = function(lhs, rhs) {
+  return lhs.x * rhs.x + lhs.y * rhs.y + lhs.z * rhs.z;
+}
+
+let crossProduct = function(lhs, rhs) {
+  return {
+    x : lhs.y * rhs.z - lhs.z * rhs.y,
+    y : lhs.z * rhs.x - lhs.x * rhs.z,
+    z : lhs.x * rhs.y - lhs.y * rhs.x,
+    w : 0
+  }
+}
+
+let length = function(vector) {
+  return Math.sqrt(dotProduct(vector, vector));
+}
+
+let normalize = function(vector) {
+  const l = length(vector);
+  return mul(vector, 1.0/l);
+}
+
+let calculateHitMatrix = function(ray_vector, plane_normal, point) {
+  // projection of ray_vector onto a plane
+  const ray_vector_projection = sub(ray_vector, mul(plane_normal, dotProduct(ray_vector, plane_normal)));
+
+  // new coordinate system axes
+  const y = plane_normal;
+  const z = normalize(neg(ray_vector_projection));
+  const x = normalize(crossProduct(y, z));
+
+  let hitMatrix = new Float32Array(16);
+
+  hitMatrix[0] = x.x;
+  hitMatrix[1] = x.y;
+  hitMatrix[2] = x.z;
+  hitMatrix[3] = 0;
+
+  hitMatrix[4] = y.x;
+  hitMatrix[5] = y.y;
+  hitMatrix[6] = y.z;
+  hitMatrix[7] = 0;
+
+  hitMatrix[8] = z.x;
+  hitMatrix[9] = z.y;
+  hitMatrix[10] = z.z;
+  hitMatrix[11] = 0;
+
+  hitMatrix[12] = point.x;
+  hitMatrix[13] = point.y;
+  hitMatrix[14] = point.z;
+  hitMatrix[15] = 1;
+
+  return hitMatrix;
+}
+
+// Single plane hit test - doesn't take into account the plane's polygon.
+// |frame| - XRFrame, |ray| - XRRay, |plane| - XRPlane, |frameOfReference| - XRSpace
+// Returns null if the hit test did not hit the |plane|.
+// If the |ray| lies on the |plane|, there are infinite intersection points &
+// we will return an object containing the plane only.
+// If the |ray| intersects with the |plane|, we will return an object containing
+// the distance along the plane as `distance`, the |plane| & |ray| as `plane` and `ray`,
+// the intersection point (in |frameOfReference| coordinates as `point`,
+// and relative to plane pose as `point_on_plane`),
+// hit test pose in |frameOfReference| as `hitMatrix`,
+// and |plane|'s pose in |frameOfReference| as `pose_matrix`.
+function hitTestPlane(frame, ray, plane, frameOfReference) {
+  const plane_pose = frame.getPose(plane.planeSpace, frameOfReference);
+  if(!plane_pose) {
+    return null;
+  }
+
+  const plane_normal = transform_point_by_matrix(
+    plane_pose.transform.matrix, {x : 0, y : 1.0, z : 0, w : 0});
+  const plane_center = normalize_perspective(
+      transform_point_by_matrix(
+        plane_pose.transform.matrix, {x : 0, y : 0, z : 0, w : 1.0}));
+
+  const ray_origin = ray.origin;
+  const ray_vector = ray.direction;
+
+  const numerator = dotProduct( sub(plane_center, ray_origin), plane_normal);
+  const denominator = dotProduct(ray_vector, plane_normal);
+
+  if(denominator < 0.0001 && denominator > -0.0001) {
+    // parallel planes
+    if(numerator < 0.0001 && numerator > -0.0001) {
+      // contained in the plane
+      console.debug("Ray contained in the plane", plane);
+      return { plane : plane };
+    } else {
+      // no hit
+      console.debug("No hit", plane);
+      return null;
+    }
+  } else {
+    // single point of intersection
+    const d =  numerator / denominator;
+    if(d < 0) {
+      // no hit - plane-line intersection exists but not for half-line
+      console.debug("No hit", d, plane);
+      return null;
+    } else {
+      const point = add(ray_origin, mul(ray_vector, d));  // hit test point coordinates in frameOfReference
+
+      let point_on_plane = transform_point_by_matrix(plane_pose.transform.inverse.matrix, point); // hit test point coodinates relative to plane pose
+      console.assert(Math.abs(point_on_plane.y) < 0.0001, "Incorrect Y coordinate of mapped point");
+
+      let hitMatrix = calculateHitMatrix(ray_vector, plane_normal, point);
+
+      return {
+        distance : d,
+        plane : plane,
+        ray : ray,
+        point : point,
+        point_on_plane : point_on_plane,
+        hitMatrix : hitMatrix,
+        pose_matrix : plane_pose.transform.matrix
+      };
+    }
+  }
+}
+
+// multiple planes hit test
+// |frame| - XRFRame, |ray| - XRRay, |frameOfReference| - XRSpace
+export function hitTest(frame, ray, frameOfReference) {
+  const planes = frame.detectedPlanes;
+
+  let hit_test_results = [];
+  planes.forEach(plane => {
+    let result = hitTestPlane(frame, ray, plane, frameOfReference);
+    if(result) {
+      // throw away results with no intersection with plane
+      hit_test_results.push(result);
+    }
+  });
+
+  // throw away all strange results (ray lies on plane)
+  let hit_test_results_with_points = hit_test_results.filter(
+    maybe_plane => typeof maybe_plane.point != "undefined");
+
+  // sort results by distance
+  hit_test_results_with_points.sort((l, r) => l.distance - r.distance);
+
+  // throw away the ones that don't fall within polygon bounds (except the bottommost plane)
+  // convert hittest results to something that the caller expects
+
+  return hit_test_results_with_points;
+}
+
+function simplifyPolygon(polygon) {
+  let result = [];
+
+  let previous_point = polygon[polygon.length - 1];
+  for(let i = 0; i < polygon.length; ++i) {
+    const current_point = polygon[i];
+
+    const segment = sub(current_point, previous_point);
+    if(length(segment) < 0.001) {
+      continue;
+    }
+
+    result.push(current_point);
+    previous_point = current_point;
+  }
+
+  return result;
+}
+
+export function extendPolygon(polygon) {
+  return polygon.map(vertex => {
+    let center_to_vertex_normal = normalize(vertex);
+    center_to_vertex_normal.w = 0;
+    const addition = mul(center_to_vertex_normal, 0.2);
+    return add(vertex, addition);
+  });
+}
+
+// 2d "cross product" of 3d points lying on a 2d plane with Y = 0
+let crossProduct2d = function(lhs, rhs) {
+  return lhs.x * rhs.z - lhs.z * rhs.x;
+}
+
+// Filters hit test results to keep only the planes for which the used ray falls
+// within their polygon. Optionally, we can keep the last horizontal plane that
+// was hit.
+export function filterHitTestResults(hitTestResults,
+                                     keep_last_plane = false,
+                                     simplify_planes = false) {
+  let result = hitTestResults.filter(hitTestResult => {
+
+    let polygon = simplify_planes ? simplifyPolygon(hitTestResult.plane.polygon)
+                                  : hitTestResult.plane.polygon;
+
+    const hit_test_point = hitTestResult.point_on_plane;
+
+    // Check if the point is on the same side from all the segments:
+    // - if yes, then it's in the polygon
+    // - if no, then it's outside of the polygon
+    // This works only for convex polygons.
+
+    let side = 0; // unknown, 1 = right, 2 = left
+    let previous_point = polygon[polygon.length - 1];
+    for(let i = 0; i < polygon.length; ++i) {
+      const current_point = polygon[i];
+
+      const line_segment = sub(current_point, previous_point);
+      const segment_direction = normalize(line_segment);
+
+      const turn_segment = sub(hit_test_point, current_point);
+      const turn_direction = normalize(turn_segment);
+
+      const cosine_ray_segment = crossProduct2d(segment_direction, turn_direction);
+      if(side == 0) {
+        if(cosine_ray_segment > 0) {
+          side = 1;
+        } else {
+          side = 2;
+        }
+      } else {
+        if(cosine_ray_segment > 0 && side == 2) return false;
+        if(cosine_ray_segment < 0 && side == 1) return false;
+      }
+
+      previous_point = current_point;
+    }
+
+    return true;
+  });
+
+  if(keep_last_plane && hitTestResults.length > 0) {
+    const last_horizontal_plane_result = hitTestResults.slice().reverse().find(
+      element => {
+        return element.plane.orientation == "horizontal";
+      });
+
+    if(last_horizontal_plane_result
+      && result.findIndex(element => element === last_horizontal_plane_result) == -1) {
+      result.push(last_horizontal_plane_result);
+    }
+  }
+
+  return result;
+}

--- a/proposals/index.html
+++ b/proposals/index.html
@@ -120,7 +120,10 @@
               description: 'Demonstrates use of a depth API in immersive-ar session. ' +
                            'The data will be accessed on the CPU.' },
 
-            { tag: 'br' },
+            { title: 'AR Plane Detection', category: 'AR',
+              path: 'plane-detection.html',
+              description: 'Demonstrates use of a plane detection API in immersive-ar session. ' +
+                           'Implements JavaScript-level hit-test and leverages Anchors API.' },
 
             { title: 'Hands Test', category: 'XR Basics',
               path: 'immersive-hands.html',

--- a/proposals/plane-detection.html
+++ b/proposals/plane-detection.html
@@ -35,8 +35,13 @@
       // three.js is covered by MIT license which can be found at:
       // https://github.com/mrdoob/three.js/blob/master/LICENSE
 
+      // The code also links to a .png file from ARCore Android SDK.
+      // It is covered by Apache 2.0 license which can be found at:
+      // https://github.com/google-ar/arcore-android-sdk/blob/c684bbda37e44099c273c3e5274fae6fccee293c/LICENSE
+
       import * as THREE from 'https://unpkg.com/three@0.127.0/build/three.module.js';
       import {WebXRButton} from '../js/util/webxr-button.js';
+      import {hitTest, filterHitTestResults} from '../js/hit-test.js';
 
       const usePlaneOrigin = document.getElementById('usePlaneOrigin');
 
@@ -58,9 +63,10 @@
 
       let container;
       let camera, scene, renderer;
-      let controller;
 
       let reticle;
+      // hitResult will be set when reticle is visible:
+      let hitResult;
 
       const planeMaterials = [];
       const lineMaterials = [
@@ -69,30 +75,38 @@
         new THREE.LineBasicMaterial({color: 0x0000ff}),
       ];
 
-      let hitTestSource = null;
-      let hitTestSourceRequested = false;
+      const lineGeometries = [
+        new THREE.BufferGeometry().setFromPoints([new THREE.Vector3(0,0,0), new THREE.Vector3(5,0,0)]),
+        new THREE.BufferGeometry().setFromPoints([new THREE.Vector3(0,0,0), new THREE.Vector3(0,5,0)]),
+        new THREE.BufferGeometry().setFromPoints([new THREE.Vector3(0,0,0), new THREE.Vector3(0,0,5)]),
+      ];
+
+      const baseOriginGroup = new THREE.Group();
+      baseOriginGroup.add(new THREE.Line(lineGeometries[0], lineMaterials[0]));
+      baseOriginGroup.add(new THREE.Line(lineGeometries[1], lineMaterials[1]));
+      baseOriginGroup.add(new THREE.Line(lineGeometries[2], lineMaterials[2]));
 
       init();
 
       function init() {
 
-        container = document.createElement( 'div' );
-        document.body.appendChild( container );
+        container = document.createElement('div');
+        document.body.appendChild(container);
 
         scene = new THREE.Scene();
 
-        camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 0.01, 20 );
+        camera = new THREE.PerspectiveCamera(70, window.innerWidth / window.innerHeight, 0.01, 20);
 
-        const light = new THREE.HemisphereLight( 0xffffff, 0xbbbbff, 1 );
-        light.position.set( 0.5, 1, 0.25 );
-        scene.add( light );
+        const light = new THREE.HemisphereLight(0xffffff, 0xbbbbff, 1);
+        light.position.set(0.5, 1, 0.25);
+        scene.add(light);
 
-        renderer = new THREE.WebGLRenderer( { antialias: true, alpha: true } );
-        renderer.setPixelRatio( window.devicePixelRatio );
-        renderer.setSize( window.innerWidth, window.innerHeight );
+        renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+        renderer.setPixelRatio(window.devicePixelRatio);
+        renderer.setSize(window.innerWidth, window.innerHeight );
         renderer.xr.enabled = true;
         renderer.autoClear = false;
-        container.appendChild( renderer.domElement );
+        container.appendChild(renderer.domElement);
 
         xrButton = new WebXRButton({
           onRequestSession: onRequestSession,
@@ -110,22 +124,6 @@
             xrButton.enabled = supported;
           });
         }
-        
-        const geometry = new THREE.CylinderGeometry(0.1, 0.1, 0.2, 32).translate(0, 0.1, 0);
-
-        const onSelect = function() {
-          if (reticle.visible) {
-            const material = new THREE.MeshPhongMaterial({ color: 0xffffff * Math.random()});
-            const mesh = new THREE.Mesh(geometry, material);
-            mesh.position.setFromMatrixPosition(reticle.matrix);
-            mesh.scale.y = Math.random() * 2 + 1;
-            scene.add(mesh);
-          }
-        }
-
-        controller = renderer.xr.getController(0);
-        controller.addEventListener('select', onSelect);
-        scene.add(controller);
 
         reticle = new THREE.Mesh(
           new THREE.RingGeometry(0.15, 0.2, 32).rotateX(-Math.PI / 2),
@@ -159,7 +157,7 @@
 
       function onRequestSession() {
         let sessionInit = {
-          requiredFeatures: ['anchors', 'plane-detection', 'hit-test'],
+          requiredFeatures: ['anchors', 'plane-detection'],
           optionalFeatures: [],
         };
         if (useDomOverlay.checked) {
@@ -176,6 +174,7 @@
       function onSessionStarted(session) {
         useDomOverlay.disabled = true;
         session.addEventListener('end', onSessionEnded);
+        session.addEventListener('select', onSelect);
 
         renderer.xr.setReferenceSpaceType('local');
         renderer.xr.setSession(session);
@@ -204,26 +203,67 @@
 
       let anchorId = 1;
       let allAnchors = new Map();
+
       function processAnchors(timestamp, frame) {
-        if(frame.trackedAnchors) {
+        const referenceSpace = renderer.xr.getReferenceSpace();
+
+        if (frame.trackedAnchors) {
           allAnchors.forEach((anchorContext, anchor) => {
-            if(!frame.trackedAnchors.has(anchor)) {
+            if (!frame.trackedAnchors.has(anchor)) {
               // anchor was removed
               allAnchors.delete(anchor);
               console.debug("Anchor no longer tracked, id=" + anchorContext.id);
+
+              scene.remove(anchorContext.mesh);
             }
           });
 
           frame.trackedAnchors.forEach(anchor => {
-            if(allAnchors.has(anchor)) {
+            if (allAnchors.has(anchor)) {
               const anchorContext = allAnchors.get(anchor);
+              const anchorPose = frame.getPose(anchor.anchorSpace, referenceSpace);
               // update pose
+              if (anchorPose) {
+                anchorContext.mesh.visible = true;
+                anchorContext.mesh.matrix.fromArray(anchorPose.transform.matrix);
+              } else {
+                anchorContext.mesh.visible = false;
+              }
             } else {
-              // new anchor
-              allAnchors.set(plane, {id: anchorId});
-              console.debug("New anchor created, id=" + anchorId);
-              anchorId++;
+              console.error("New anchors should be processed in a createAnchor(...).then() promise");
             }
+          });
+        }
+      }
+
+      const geometry = new THREE.CylinderGeometry(0.1, 0.1, 0.2, 32).translate(0, 0.1, 0);
+
+      function onSelect(event) {
+        if (reticle.visible) {
+          const material = new THREE.MeshPhongMaterial({ color: 0xffffff * Math.random()});
+          const mesh = new THREE.Mesh(geometry, material);
+          mesh.scale.y = Math.random() * 2 + 1;
+          mesh.visible = false;
+          mesh.matrixAutoUpdate = false;
+
+          // Reticle matrix is expressed relative to `referenceSpace`, but we need to
+          // pass a pose relative to the plane space. Luckily, our JS-side hit test
+          // contains that information as well.
+          event.frame.createAnchor(
+            new XRRigidTransform(hitResult.point_on_plane),
+            hitResult.plane.planeSpace)
+          .then((anchor) => {
+            scene.add(mesh);
+
+            // new anchor created:
+            const anchorContext = {
+              id: anchorId,
+              mesh: mesh,
+            }
+
+            allAnchors.set(anchor, anchorContext);
+            console.debug("New anchor created, id=" + anchorId);
+            anchorId++;
           });
         }
       }
@@ -257,9 +297,9 @@
       function processPlanes(timestamp, frame) {
         const referenceSpace = renderer.xr.getReferenceSpace();
 
-        if(frame.detectedPlanes) {
+        if (frame.detectedPlanes) {
           allPlanes.forEach((planeContext, plane) => {
-            if(!frame.detectedPlanes.has(plane)) {
+            if (!frame.detectedPlanes.has(plane)) {
               // plane was removed
               allPlanes.delete(plane);
               console.debug("Plane no longer tracked, id=" + planeContext.id);
@@ -270,12 +310,14 @@
 
           frame.detectedPlanes.forEach(plane => {
             const planePose = frame.getPose(plane.planeSpace, referenceSpace);
+            let planeMesh;
 
-            if(allPlanes.has(plane)) {
+            if (allPlanes.has(plane)) {
               // may have been updated:
               const planeContext = allPlanes.get(plane);
+              planeMesh = planeContext.mesh;
 
-              if(planeContext.timestamp < plane.lastChangedTime) {
+              if (planeContext.timestamp < plane.lastChangedTime) {
                 // updated!
                 planeContext.timestamp = plane.lastChangedTime;
 
@@ -283,35 +325,21 @@
                 planeContext.mesh.geometry.dispose();
                 planeContext.mesh.geometry = geometry;
               }
-
-              planeContext.mesh.matrix.fromArray(planePose.transform.matrix);
             } else {
               // new plane
               
               // Create geometry:
               const geometry = createGeometryFromPolygon(plane.polygon);
-              const planeMesh = new THREE.Mesh(geometry,
+              planeMesh = new THREE.Mesh(geometry,
                 planeMaterials[planeId % planeMaterials.length]
               );
               
               planeMesh.matrixAutoUpdate = false;
-              planeMesh.visible = true;
-
-              planeMesh.matrix.fromArray( planePose.transform.matrix );
 
               scene.add(planeMesh);
 
               // Create plane origin visualizer:
-              const originGroup = new THREE.Group();
-              originGroup.add(new THREE.Line(
-                new THREE.BufferGeometry().setFromPoints([new THREE.Vector3(0,0,0), new THREE.Vector3(5,0,0)]),
-                lineMaterials[0]));
-              originGroup.add(new THREE.Line(
-                new THREE.BufferGeometry().setFromPoints([new THREE.Vector3(0,0,0), new THREE.Vector3(0,5,0)]),
-                lineMaterials[1]));
-              originGroup.add(new THREE.Line(
-                new THREE.BufferGeometry().setFromPoints([new THREE.Vector3(0,0,0), new THREE.Vector3(0,0,5)]),
-                lineMaterials[2]));
+              const originGroup = baseOriginGroup.clone();
               originGroup.visible = usePlaneOrigin.checked;
 
               planeMesh.add(originGroup);
@@ -328,46 +356,53 @@
               console.debug("New plane detected, id=" + planeId);
               planeId++;
             }
+
+            if (planePose) {
+              planeMesh.visible = true;
+              planeMesh.matrix.fromArray(planePose.transform.matrix);
+            } else {
+              planeMesh.visible = false;
+            }
           });
         }
       }
 
-      function render( timestamp, frame ) {
-        if ( frame ) {
+      function render(timestamp, frame) {
+        if (frame) {
           processAnchors(timestamp, frame);
           processPlanes(timestamp, frame);
 
           const referenceSpace = renderer.xr.getReferenceSpace();
           const session = renderer.xr.getSession();
 
-          if ( hitTestSourceRequested === false ) {
-            session.requestReferenceSpace( 'viewer' ).then( function ( referenceSpace ) {
-              session.requestHitTestSource( { space: referenceSpace } ).then( function ( source ) {
-                hitTestSource = source;
-              } );
-            } );
+          reticle.visible = false;
+          hitResult = null;
 
-            session.addEventListener( 'end', function () {
-              hitTestSourceRequested = false;
-              hitTestSource = null;
-            } );
+          const pose = frame.getViewerPose(referenceSpace);
+          if (pose) {
+            const ray = new XRRay(pose.transform);
 
-            hitTestSourceRequested = true;
-          }
+            // Perform a JS-side hit test against mathematical (infinte) planes:
+            const hitTestResults = hitTest(frame, ray, referenceSpace);
+            // Filter results down to the ones that fall within plane's polygon:
+            const hitTestFiltered = filterHitTestResults(hitTestResults);
 
-          if ( hitTestSource ) {
-            const hitTestResults = frame.getHitTestResults( hitTestSource );
+            if (hitTestFiltered && hitTestFiltered.length > 0) {
+              hitResult = hitTestFiltered[0];
 
-            if ( hitTestResults.length ) {
-              const hit = hitTestResults[ 0 ];
+              const hitMatrix = hitResult.hitMatrix;
+
+              hitMatrix[12] += 0.001; // move the reticle slightly away from the plane
+              hitMatrix[13] += 0.001; // center to prevent z-fighting with plane meshes
+              hitMatrix[14] += 0.001;
 
               reticle.visible = true;
-              reticle.matrix.fromArray( hit.getPose( referenceSpace ).transform.matrix );
-            } else {
-              reticle.visible = false;
+
+              reticle.matrix.fromArray(hitMatrix);
             }
           }
-          renderer.render( scene, camera );
+
+          renderer.render(scene, camera);
         }
       }
 

--- a/proposals/plane-detection.html
+++ b/proposals/plane-detection.html
@@ -31,8 +31,28 @@
     </header>
 
     <script type="module">
+      // Code adapted from three.js' WebXR hit test sample.
+      // three.js is covered by MIT license which can be found at:
+      // https://github.com/mrdoob/three.js/blob/master/LICENSE
+
       import * as THREE from 'https://unpkg.com/three@0.127.0/build/three.module.js';
       import {WebXRButton} from '../js/util/webxr-button.js';
+
+      const usePlaneOrigin = document.getElementById('usePlaneOrigin');
+
+      const allPlaneOrigins = [];
+      usePlaneOrigin.addEventListener('input', element =>{
+        console.log("Changing state of plane origins");
+        allPlaneOrigins.forEach(group => {
+          group.visible = usePlaneOrigin.checked
+        });
+      });
+
+      // Suppress XR events for interactions with the DOM overlay
+      document.querySelector('header').addEventListener('beforexrselect', (ev) => {
+        console.log(ev.type);
+        ev.preventDefault();
+      });
 
       let xrButton = null;
 
@@ -42,13 +62,17 @@
 
       let reticle;
 
-      let planeMaterials = [];
+      const planeMaterials = [];
+      const lineMaterials = [
+        new THREE.LineBasicMaterial({color: 0xff0000}),
+        new THREE.LineBasicMaterial({color: 0x00ff00}),
+        new THREE.LineBasicMaterial({color: 0x0000ff}),
+      ];
 
       let hitTestSource = null;
       let hitTestSourceRequested = false;
 
       init();
-      // animate();
 
       function init() {
 
@@ -87,29 +111,29 @@
           });
         }
         
-        const geometry = new THREE.CylinderGeometry( 0.1, 0.1, 0.2, 32 ).translate( 0, 0.1, 0 );
+        const geometry = new THREE.CylinderGeometry(0.1, 0.1, 0.2, 32).translate(0, 0.1, 0);
 
         const onSelect = function() {
-          if ( reticle.visible ) {
-            const material = new THREE.MeshPhongMaterial( { color: 0xffffff * Math.random() } );
-            const mesh = new THREE.Mesh( geometry, material );
-            mesh.position.setFromMatrixPosition( reticle.matrix );
+          if (reticle.visible) {
+            const material = new THREE.MeshPhongMaterial({ color: 0xffffff * Math.random()});
+            const mesh = new THREE.Mesh(geometry, material);
+            mesh.position.setFromMatrixPosition(reticle.matrix);
             mesh.scale.y = Math.random() * 2 + 1;
-            scene.add( mesh );
+            scene.add(mesh);
           }
         }
 
-        controller = renderer.xr.getController( 0 );
-        controller.addEventListener( 'select', onSelect );
-        scene.add( controller );
+        controller = renderer.xr.getController(0);
+        controller.addEventListener('select', onSelect);
+        scene.add(controller);
 
         reticle = new THREE.Mesh(
-          new THREE.RingGeometry( 0.15, 0.2, 32 ).rotateX( - Math.PI / 2 ),
+          new THREE.RingGeometry(0.15, 0.2, 32).rotateX(-Math.PI / 2),
           new THREE.MeshBasicMaterial()
         );
         reticle.matrixAutoUpdate = false;
         reticle.visible = false;
-        scene.add( reticle );
+        scene.add(reticle);
 
         const loadManager = new THREE.LoadingManager();
         const loader = new THREE.TextureLoader(loadManager);
@@ -130,8 +154,7 @@
         planeMaterials.push(createPlaneMaterial({color: 0x00ffff}));
         planeMaterials.push(createPlaneMaterial({color: 0xff00ff}));
 
-        //
-        window.addEventListener( 'resize', onWindowResize );
+        window.addEventListener('resize', onWindowResize);
       }
 
       function onRequestSession() {
@@ -152,12 +175,12 @@
 
       function onSessionStarted(session) {
         useDomOverlay.disabled = true;
-        session.addEventListener( 'end', onSessionEnded );
+        session.addEventListener('end', onSessionEnded);
 
-        renderer.xr.setReferenceSpaceType( 'local' );
-        renderer.xr.setSession( session );
+        renderer.xr.setReferenceSpaceType('local');
+        renderer.xr.setSession(session);
 
-        renderer.setAnimationLoop( render );
+        renderer.setAnimationLoop(render);
       }
 
       function onEndSession(session) {
@@ -176,11 +199,7 @@
         camera.aspect = window.innerWidth / window.innerHeight;
         camera.updateProjectionMatrix();
 
-        renderer.setSize( window.innerWidth, window.innerHeight );
-      }
-
-      function animate() {
-        renderer.setAnimationLoop( render );
+        renderer.setSize(window.innerWidth, window.innerHeight);
       }
 
       let anchorId = 1;
@@ -255,38 +274,21 @@
             if(allPlanes.has(plane)) {
               // may have been updated:
               const planeContext = allPlanes.get(plane);
+
               if(planeContext.timestamp < plane.lastChangedTime) {
                 // updated!
                 planeContext.timestamp = plane.lastChangedTime;
 
-                // scene.remove(planeContext.mesh);
-
                 const geometry = createGeometryFromPolygon(plane.polygon);
                 planeContext.mesh.geometry.dispose();
                 planeContext.mesh.geometry = geometry;
-                
-                // const planeMesh = new THREE.Mesh(geometry,
-                //   planeMaterials[planeId % planeMaterials.length]
-                // );
-                  
-                // planeMesh.matrixAutoUpdate = false;
-                // planeMesh.visible = true;
-                  
-                // scene.add(planeMesh);
-
-                // planeContext.mesh = planeMesh;
               }
 
               planeContext.mesh.matrix.fromArray(planePose.transform.matrix);
-
-              // allPlanes.set(plane, planeContext);
             } else {
               // new plane
-              const planeContext = {
-                id: planeId,
-                timestamp: plane.lastChangedTime,
-              };
               
+              // Create geometry:
               const geometry = createGeometryFromPolygon(plane.polygon);
               const planeMesh = new THREE.Mesh(geometry,
                 planeMaterials[planeId % planeMaterials.length]
@@ -298,7 +300,29 @@
               planeMesh.matrix.fromArray( planePose.transform.matrix );
 
               scene.add(planeMesh);
-              planeContext.mesh = planeMesh;
+
+              // Create plane origin visualizer:
+              const originGroup = new THREE.Group();
+              originGroup.add(new THREE.Line(
+                new THREE.BufferGeometry().setFromPoints([new THREE.Vector3(0,0,0), new THREE.Vector3(5,0,0)]),
+                lineMaterials[0]));
+              originGroup.add(new THREE.Line(
+                new THREE.BufferGeometry().setFromPoints([new THREE.Vector3(0,0,0), new THREE.Vector3(0,5,0)]),
+                lineMaterials[1]));
+              originGroup.add(new THREE.Line(
+                new THREE.BufferGeometry().setFromPoints([new THREE.Vector3(0,0,0), new THREE.Vector3(0,0,5)]),
+                lineMaterials[2]));
+              originGroup.visible = usePlaneOrigin.checked;
+
+              planeMesh.add(originGroup);
+              allPlaneOrigins.push(originGroup);
+
+              const planeContext = {
+                id: planeId,
+                timestamp: plane.lastChangedTime,
+                mesh: planeMesh,
+                origin: originGroup,
+              };
 
               allPlanes.set(plane, planeContext);
               console.debug("New plane detected, id=" + planeId);

--- a/proposals/plane-detection.html
+++ b/proposals/plane-detection.html
@@ -1,0 +1,352 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset='utf-8'>
+    <meta name='viewport' content='width=device-width, initial-scale=1, user-scalable=no'>
+    <meta name='mobile-web-app-capable' content='yes'>
+    <meta name='apple-mobile-web-app-capable' content='yes'>
+
+    <title>AR Plane Detection</title>
+
+    <link href='../css/common.css' rel='stylesheet'></link>
+
+  </head>
+  <body>
+    <header>
+      <details open>
+        <summary>AR Plane Detection with Anchors</summary>
+        This sample demonstrates using the Plane Detection feature with Anchors,
+        including implementation of synchronous hit test in JavaScript
+        leveraging obtained plane data and anchors API to position objects.
+        <p>
+          <input id="usePlaneOrigin" type="checkbox" checked>
+          <label for="usePlaneOrigin">Plane coordinate system visible</label><br/>
+
+          <input id="useDomOverlay" type="checkbox" checked>
+          <label for="useDomOverlay">Enable DOM Overlay</label><br/>
+
+          <a class="back" href="./index.html">Back</a>
+        </p>
+      </details>
+    </header>
+
+    <script type="module">
+      import * as THREE from 'https://unpkg.com/three@0.127.0/build/three.module.js';
+      import {WebXRButton} from '../js/util/webxr-button.js';
+
+      let xrButton = null;
+
+      let container;
+      let camera, scene, renderer;
+      let controller;
+
+      let reticle;
+
+      let planeMaterials = [];
+
+      let hitTestSource = null;
+      let hitTestSourceRequested = false;
+
+      init();
+      // animate();
+
+      function init() {
+
+        container = document.createElement( 'div' );
+        document.body.appendChild( container );
+
+        scene = new THREE.Scene();
+
+        camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 0.01, 20 );
+
+        const light = new THREE.HemisphereLight( 0xffffff, 0xbbbbff, 1 );
+        light.position.set( 0.5, 1, 0.25 );
+        scene.add( light );
+
+        renderer = new THREE.WebGLRenderer( { antialias: true, alpha: true } );
+        renderer.setPixelRatio( window.devicePixelRatio );
+        renderer.setSize( window.innerWidth, window.innerHeight );
+        renderer.xr.enabled = true;
+        renderer.autoClear = false;
+        container.appendChild( renderer.domElement );
+
+        xrButton = new WebXRButton({
+          onRequestSession: onRequestSession,
+          onEndSession: onEndSession,
+          textEnterXRTitle: "START AR",
+          textXRNotFoundTitle: "AR NOT FOUND",
+          textExitXRTitle: "EXIT AR",
+        });
+
+        document.querySelector('header').appendChild(xrButton.domElement);
+
+        if (navigator.xr) {
+          navigator.xr.isSessionSupported('immersive-ar')
+                      .then((supported) => {
+            xrButton.enabled = supported;
+          });
+        }
+        
+        const geometry = new THREE.CylinderGeometry( 0.1, 0.1, 0.2, 32 ).translate( 0, 0.1, 0 );
+
+        const onSelect = function() {
+          if ( reticle.visible ) {
+            const material = new THREE.MeshPhongMaterial( { color: 0xffffff * Math.random() } );
+            const mesh = new THREE.Mesh( geometry, material );
+            mesh.position.setFromMatrixPosition( reticle.matrix );
+            mesh.scale.y = Math.random() * 2 + 1;
+            scene.add( mesh );
+          }
+        }
+
+        controller = renderer.xr.getController( 0 );
+        controller.addEventListener( 'select', onSelect );
+        scene.add( controller );
+
+        reticle = new THREE.Mesh(
+          new THREE.RingGeometry( 0.15, 0.2, 32 ).rotateX( - Math.PI / 2 ),
+          new THREE.MeshBasicMaterial()
+        );
+        reticle.matrixAutoUpdate = false;
+        reticle.visible = false;
+        scene.add( reticle );
+
+        const loadManager = new THREE.LoadingManager();
+        const loader = new THREE.TextureLoader(loadManager);
+        const gridTexture = loader.load('https://raw.githubusercontent.com/google-ar/arcore-android-sdk/c684bbda37e44099c273c3e5274fae6fccee293c/samples/hello_ar_c/app/src/main/assets/models/trigrid.png');
+        gridTexture.wrapS = THREE.RepeatWrapping;
+        gridTexture.wrapT = THREE.RepeatWrapping;
+
+        const createPlaneMaterial = (params) => 
+          new THREE.MeshBasicMaterial(Object.assign(params, {
+            map: gridTexture,
+            opacity: 0.5,
+            transparent: true,
+          }));
+        planeMaterials.push(createPlaneMaterial({color: 0xff0000}));
+        planeMaterials.push(createPlaneMaterial({color: 0x00ff00}));
+        planeMaterials.push(createPlaneMaterial({color: 0x0000ff}));
+        planeMaterials.push(createPlaneMaterial({color: 0xffff00}));
+        planeMaterials.push(createPlaneMaterial({color: 0x00ffff}));
+        planeMaterials.push(createPlaneMaterial({color: 0xff00ff}));
+
+        //
+        window.addEventListener( 'resize', onWindowResize );
+      }
+
+      function onRequestSession() {
+        let sessionInit = {
+          requiredFeatures: ['anchors', 'plane-detection', 'hit-test'],
+          optionalFeatures: [],
+        };
+        if (useDomOverlay.checked) {
+          sessionInit.optionalFeatures.push('dom-overlay');
+          sessionInit.domOverlay = {root: document.body};
+        }
+        navigator.xr.requestSession('immersive-ar', sessionInit).then((session) => {
+          session.mode = 'immersive-ar';
+          xrButton.setSession(session);
+          onSessionStarted(session);
+        });
+      }
+
+      function onSessionStarted(session) {
+        useDomOverlay.disabled = true;
+        session.addEventListener( 'end', onSessionEnded );
+
+        renderer.xr.setReferenceSpaceType( 'local' );
+        renderer.xr.setSession( session );
+
+        renderer.setAnimationLoop( render );
+      }
+
+      function onEndSession(session) {
+        session.end();
+      }
+
+      function onSessionEnded(event) {
+        useDomOverlay.disabled = false;
+        xrButton.setSession(null);
+
+        renderer.setAnimationLoop(null);
+        renderer.xr.setSession(null)
+      }
+
+      function onWindowResize() {
+        camera.aspect = window.innerWidth / window.innerHeight;
+        camera.updateProjectionMatrix();
+
+        renderer.setSize( window.innerWidth, window.innerHeight );
+      }
+
+      function animate() {
+        renderer.setAnimationLoop( render );
+      }
+
+      let anchorId = 1;
+      let allAnchors = new Map();
+      function processAnchors(timestamp, frame) {
+        if(frame.trackedAnchors) {
+          allAnchors.forEach((anchorContext, anchor) => {
+            if(!frame.trackedAnchors.has(anchor)) {
+              // anchor was removed
+              allAnchors.delete(anchor);
+              console.debug("Anchor no longer tracked, id=" + anchorContext.id);
+            }
+          });
+
+          frame.trackedAnchors.forEach(anchor => {
+            if(allAnchors.has(anchor)) {
+              const anchorContext = allAnchors.get(anchor);
+              // update pose
+            } else {
+              // new anchor
+              allAnchors.set(plane, {id: anchorId});
+              console.debug("New anchor created, id=" + anchorId);
+              anchorId++;
+            }
+          });
+        }
+      }
+
+      function createGeometryFromPolygon(polygon) {
+        const geometry = new THREE.BufferGeometry();
+
+        const vertices = [];
+        const uvs = [];
+        polygon.forEach(point => {
+          vertices.push(point.x, point.y, point.z);
+          uvs.push(point.x, point.z);
+        })
+
+        const indices = [];
+        for(let i = 2; i < polygon.length; ++i) {
+          indices.push(0, i-1, i);
+        }
+
+        geometry.setAttribute('position',
+          new THREE.BufferAttribute(new Float32Array(vertices), 3));
+        geometry.setAttribute('uv',
+          new THREE.BufferAttribute(new Float32Array(uvs), 2))
+        geometry.setIndex(indices);
+
+        return geometry;
+      }
+
+      let planeId = 1;
+      let allPlanes = new Map();
+      function processPlanes(timestamp, frame) {
+        const referenceSpace = renderer.xr.getReferenceSpace();
+
+        if(frame.detectedPlanes) {
+          allPlanes.forEach((planeContext, plane) => {
+            if(!frame.detectedPlanes.has(plane)) {
+              // plane was removed
+              allPlanes.delete(plane);
+              console.debug("Plane no longer tracked, id=" + planeContext.id);
+
+              scene.remove(planeContext.mesh);
+            }
+          });
+
+          frame.detectedPlanes.forEach(plane => {
+            const planePose = frame.getPose(plane.planeSpace, referenceSpace);
+
+            if(allPlanes.has(plane)) {
+              // may have been updated:
+              const planeContext = allPlanes.get(plane);
+              if(planeContext.timestamp < plane.lastChangedTime) {
+                // updated!
+                planeContext.timestamp = plane.lastChangedTime;
+
+                // scene.remove(planeContext.mesh);
+
+                const geometry = createGeometryFromPolygon(plane.polygon);
+                planeContext.mesh.geometry.dispose();
+                planeContext.mesh.geometry = geometry;
+                
+                // const planeMesh = new THREE.Mesh(geometry,
+                //   planeMaterials[planeId % planeMaterials.length]
+                // );
+                  
+                // planeMesh.matrixAutoUpdate = false;
+                // planeMesh.visible = true;
+                  
+                // scene.add(planeMesh);
+
+                // planeContext.mesh = planeMesh;
+              }
+
+              planeContext.mesh.matrix.fromArray(planePose.transform.matrix);
+
+              // allPlanes.set(plane, planeContext);
+            } else {
+              // new plane
+              const planeContext = {
+                id: planeId,
+                timestamp: plane.lastChangedTime,
+              };
+              
+              const geometry = createGeometryFromPolygon(plane.polygon);
+              const planeMesh = new THREE.Mesh(geometry,
+                planeMaterials[planeId % planeMaterials.length]
+              );
+              
+              planeMesh.matrixAutoUpdate = false;
+              planeMesh.visible = true;
+
+              planeMesh.matrix.fromArray( planePose.transform.matrix );
+
+              scene.add(planeMesh);
+              planeContext.mesh = planeMesh;
+
+              allPlanes.set(plane, planeContext);
+              console.debug("New plane detected, id=" + planeId);
+              planeId++;
+            }
+          });
+        }
+      }
+
+      function render( timestamp, frame ) {
+        if ( frame ) {
+          processAnchors(timestamp, frame);
+          processPlanes(timestamp, frame);
+
+          const referenceSpace = renderer.xr.getReferenceSpace();
+          const session = renderer.xr.getSession();
+
+          if ( hitTestSourceRequested === false ) {
+            session.requestReferenceSpace( 'viewer' ).then( function ( referenceSpace ) {
+              session.requestHitTestSource( { space: referenceSpace } ).then( function ( source ) {
+                hitTestSource = source;
+              } );
+            } );
+
+            session.addEventListener( 'end', function () {
+              hitTestSourceRequested = false;
+              hitTestSource = null;
+            } );
+
+            hitTestSourceRequested = true;
+          }
+
+          if ( hitTestSource ) {
+            const hitTestResults = frame.getHitTestResults( hitTestSource );
+
+            if ( hitTestResults.length ) {
+              const hit = hitTestResults[ 0 ];
+
+              reticle.visible = true;
+              reticle.matrix.fromArray( hit.getPose( referenceSpace ).transform.matrix );
+            } else {
+              reticle.visible = false;
+            }
+          }
+          renderer.render( scene, camera );
+        }
+      }
+
+    </script>
+  </body>
+</html>

--- a/proposals/plane-detection.html
+++ b/proposals/plane-detection.html
@@ -6,6 +6,8 @@
     <meta name='mobile-web-app-capable' content='yes'>
     <meta name='apple-mobile-web-app-capable' content='yes'>
 
+    <meta http-equiv="origin-trial" content="Ahfj+MLeL6bh+LNmpnSdepftxoDHHwjUG2KWZ4jjCb1WoZxtBlzF3cDHuJNVqnhr3HXJwQ+kLaw57NO15S0mRwwAAABkeyJvcmlnaW4iOiJodHRwczovL2ltbWVyc2l2ZS13ZWIuZ2l0aHViLmlvOjQ0MyIsImZlYXR1cmUiOiJXZWJYUlBsYW5lRGV0ZWN0aW9uIiwiZXhwaXJ5IjoxNjI5ODQ5NTk5fQ==">
+
     <title>AR Plane Detection</title>
 
     <link href='../css/common.css' rel='stylesheet'></link>


### PR DESCRIPTION
Add plane detection API sample.

Things to note:
- The sample perma-links to the .png file from ARCore Android SDK repository and mentions that this is the case in the comment, along with the link to the license - I'm not sure if this is the right way to go here. I could also add the file directly to our repository, in which case we should probably also include a copy of the license somewhere.
- The sample is a heavily modified version of three.js' ar hit test sample - I have mentioned that in the comment and linked to the three.js' license.
- The sample includes a JavaScript-side hit test implementation to showcase that plane detection API allows the sites to implement a synchronous hit-test if they choose so.
- The sample also leverages Anchors API for object placement, and includes Chrome's Origin Trial token.