### PR TITLE
Fixed bug with missing sessionOptions

### DIFF
--- a/report/index.html
+++ b/report/index.html
@@ -435,7 +435,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             };
 
             if (name == 'immersive-ar') {
-              optionalFeatures.push('dom-overlay');
+              sessionOptions.optionalFeatures.push('dom-overlay');
               sessionOptions.domOverlay = { root: document.getElementById('session-report') };
             }
 


### PR DESCRIPTION
I ran into this issue when using the report face. The sessionOptions variable name was missing. It's added now.