### PR TITLE
Add anchor support to hittest sample

### DIFF
--- a/hit-test-anchors.html
+++ b/hit-test-anchors.html
@@ -1,0 +1,236 @@
+<!doctype html>
+<!--
+Copyright 2018 The Immersive Web Community Group
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+-->
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <meta name='viewport' content='width=device-width, initial-scale=1, user-scalable=no'>
+    <meta name='mobile-web-app-capable' content='yes'>
+    <meta name='apple-mobile-web-app-capable' content='yes'>
+    <link rel='icon' type='image/png' sizes='32x32' href='favicon-32x32.png'>
+    <link rel='icon' type='image/png' sizes='96x96' href='favicon-96x96.png'>
+    <link rel='stylesheet' href='css/common.css'>
+
+    <title>Hit Test</title>
+  </head>
+  <body>
+    <header>
+      <details open>
+        <summary>Hit Test</summary>
+        <p>
+          This sample demonstrates use of hit testing to place virtual objects on real-world surfaces.
+          <a class="back" href="./">Back</a>
+        </p>
+      </details>
+    </header>
+    <script type="module">
+      import {WebXRButton} from './js/util/webxr-button.js';
+      import {Scene} from './js/render/scenes/scene.js';
+      import {Renderer, createWebGLContext} from './js/render/core/renderer.js';
+      import {Node} from './js/render/core/node.js';
+      import {Gltf2Node} from './js/render/nodes/gltf2.js';
+      import {DropShadowNode} from './js/render/nodes/drop-shadow.js';
+      import {vec3} from './js/render/math/gl-matrix.js';
+      import {Ray} from './js/render/math/ray.js';
+
+      // XR globals.
+      let xrButton = null;
+      let xrRefSpace = null;
+      let xrViewerSpace = null;
+      let xrHitTestSource = null;
+
+      // WebGL scene globals.
+      let gl = null;
+      let renderer = null;
+      let scene = new Scene();
+      scene.enableStats(false);
+
+      let arObject = new Node();
+      arObject.visible = false;
+      scene.addNode(arObject);
+
+      let flower = new Gltf2Node({url: 'media/gltf/sunflower/sunflower.gltf'});
+      arObject.addNode(flower);
+
+      let reticle = new Gltf2Node({url: 'media/gltf/reticle/reticle.gltf'});
+      reticle.visible = false;
+      scene.addNode(reticle);
+      let reticleHitTestResult = null;
+
+      // Having a really simple drop shadow underneath an object helps ground
+      // it in the world without adding much complexity.
+      let shadow = new DropShadowNode();
+      vec3.set(shadow.scale, 0.15, 0.15, 0.15);
+      arObject.addNode(shadow);
+
+      const MAX_FLOWERS = 30;
+      let flowers = [];
+
+      // Ensure the background is transparent for AR.
+      scene.clear = false;
+
+      function initXR() {
+        xrButton = new WebXRButton({
+          onRequestSession: onRequestSession,
+          onEndSession: onEndSession,
+          textEnterXRTitle: "START AR",
+          textXRNotFoundTitle: "AR NOT FOUND",
+          textExitXRTitle: "EXIT  AR",
+        });
+        document.querySelector('header').appendChild(xrButton.domElement);
+
+        if (navigator.xr) {
+          navigator.xr.isSessionSupported('immersive-ar')
+                      .then((supported) => {
+            xrButton.enabled = supported;
+          });
+        }
+      }
+
+      function onRequestSession() {
+        return navigator.xr.requestSession('immersive-ar', {requiredFeatures: ['local', 'hit-test', 'anchors']})
+                           .then((session) => {
+          xrButton.setSession(session);
+          onSessionStarted(session);
+        });
+      }
+
+      function onSessionStarted(session) {
+        session.addEventListener('end', onSessionEnded);
+        session.addEventListener('select', onSelect);
+
+        if (!gl) {
+          gl = createWebGLContext({
+            xrCompatible: true
+          });
+
+          renderer = new Renderer(gl);
+
+          scene.setRenderer(renderer);
+        }
+
+        session.updateRenderState({ baseLayer: new XRWebGLLayer(session, gl) });
+
+        // In this sample we want to cast a ray straight out from the viewer's
+        // position and render a reticle where it intersects with a real world
+        // surface. To do this we first get the viewer space, then create a
+        // hitTestSource that tracks it.
+        session.requestReferenceSpace('viewer').then((refSpace) => {
+          xrViewerSpace = refSpace;
+          session.requestHitTestSource({ space: xrViewerSpace }).then((hitTestSource) => {
+            xrHitTestSource = hitTestSource;
+          });
+        });
+
+        session.requestReferenceSpace('local').then((refSpace) => {
+          xrRefSpace = refSpace;
+
+          session.requestAnimationFrame(onXRFrame);
+        });
+      }
+
+      function onEndSession(session) {
+        anchoredObjects.clear();
+        xrHitTestSource.cancel();
+        xrHitTestSource = null;
+        session.end();
+      }
+
+      function onSessionEnded(event) {
+        xrButton.setSession(null);
+      }
+
+      const MAX_ANCHORED_OBJECTS = 30;
+      let anchoredObjects = [];
+      function addAnchoredObjectsToScene(anchor) {
+        let flower = new Gltf2Node({url: 'media/gltf/sunflower/sunflower.gltf'});
+        scene.addNode(flower);
+        anchoredObjects.push({
+          anchoredObject: flower,
+          anchor: anchor
+        });
+
+        // For performance reasons if we add too many objects start
+        // removing the oldest ones to keep the scene complexity
+        // from growing too much.
+        if (anchoredObjects.length > MAX_ANCHORED_OBJECTS) {
+          let objectToRemove = anchoredObjects.shift();
+          scene.removeNode(objectToRemove.anchoredObject);
+          objectToRemove.anchor.delete();
+        }
+      }
+
+      let rayOrigin = vec3.create();
+      let rayDirection = vec3.create();
+      function onSelect(event) {
+        if (reticle.visible) {
+          // Create an anchor.
+          reticleHitTestResult.createAnchor().then((anchor) => {
+            addAnchoredObjectsToScene(anchor);
+          }, (error) => {
+            console.error("Could not create anchor: " + error);
+          });
+        }
+      }
+
+      // Called every time a XRSession requests that a new frame be drawn.
+      function onXRFrame(t, frame) {
+        let session = frame.session;
+        let pose = frame.getViewerPose(xrRefSpace);
+
+        reticle.visible = false;
+
+        // If we have a hit test source, get its results for the frame
+        // and use the pose to display a reticle in the scene.
+        if (xrHitTestSource && pose) {
+          let hitTestResults = frame.getHitTestResults(xrHitTestSource);
+          if (hitTestResults.length > 0) {
+            let pose = hitTestResults[0].getPose(xrRefSpace);
+            reticle.visible = true;
+            reticle.matrix = pose.transform.matrix;
+            reticleHitTestResult = hitTestResults[0];
+          }
+        }
+
+        for (const {anchoredObject, anchor} of anchoredObjects) {
+          // only update the object's position if it's still in the list
+          // of frame.trackedAnchors
+          if (!frame.trackedAnchors.has(anchor)) {
+            continue;
+          }
+          const anchorPose = frame.getPose(anchor.anchorSpace, xrRefSpace);
+          anchoredObject.matrix = anchorPose.transform.matrix;
+        }
+
+        scene.startFrame();
+
+        session.requestAnimationFrame(onXRFrame);
+
+        scene.drawXRFrame(frame, pose);
+
+        scene.endFrame();
+      }
+
+      // Start the XR application.
+      initXR();
+    </script>
+  </body>
+</html>

--- a/hit-test-anchors.html
+++ b/hit-test-anchors.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <!--
-Copyright 2018 The Immersive Web Community Group
+Copyright 2021 The Immersive Web Community Group
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -29,14 +29,14 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     <link rel='icon' type='image/png' sizes='96x96' href='favicon-96x96.png'>
     <link rel='stylesheet' href='css/common.css'>
 
-    <title>Hit Test</title>
+    <title>Hit Test with Anchors</title>
   </head>
   <body>
     <header>
       <details open>
-        <summary>Hit Test</summary>
+        <summary>Hit Test with Anchors</summary>
         <p>
-          This sample demonstrates use of hit testing to place virtual objects on real-world surfaces.
+          This sample demonstrates use of hit testing to find intersections on real-world surfaces and then use Anchors to attach the virtual object to that location.
           <a class="back" href="./">Back</a>
         </p>
       </details>

--- a/hit-test.html
+++ b/hit-test.html
@@ -1,14 +1,17 @@
 <!doctype html>
 <!--
 Copyright 2018 The Immersive Web Community Group
+
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
 the Software without restriction, including without limitation the rights to
 use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
 the Software, and to permit persons to whom the Software is furnished to do so,
 subject to the following conditions:
+
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
+
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
 FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR

--- a/hit-test.html
+++ b/hit-test.html
@@ -73,6 +73,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       let reticle = new Gltf2Node({url: 'media/gltf/reticle/reticle.gltf'});
       reticle.visible = false;
       scene.addNode(reticle);
+      let reticleHitTestResult = null;
 
       // Having a really simple drop shadow underneath an object helps ground
       // it in the world without adding much complexity.
@@ -105,7 +106,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       }
 
       function onRequestSession() {
-        return navigator.xr.requestSession('immersive-ar', {requiredFeatures: ['local', 'hit-test']})
+        return navigator.xr.requestSession('immersive-ar', {requiredFeatures: ['local', 'hit-test', 'anchors']})
                            .then((session) => {
           xrButton.setSession(session);
           onSessionStarted(session);
@@ -147,6 +148,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       }
 
       function onEndSession(session) {
+        anchoredObjects.clear();
         xrHitTestSource.cancel();
         xrHitTestSource = null;
         session.end();
@@ -156,22 +158,23 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         xrButton.setSession(null);
       }
 
-      // Adds a new object to the scene at the
-      // specified transform.
-      function addARObjectAt(matrix) {
-        let newFlower = arObject.clone();
-        newFlower.visible = true;
-        newFlower.matrix = matrix;
-        scene.addNode(newFlower);
-
-        flowers.push(newFlower);
+      const MAX_ANCHORED_OBJECTS = 30;
+      let anchoredObjects = [];
+      function addAnchoredObjectsToScene(anchor) {
+        let flower = new Gltf2Node({url: 'media/gltf/sunflower/sunflower.gltf'});
+        scene.addNode(flower);
+        anchoredObjects.push({
+          anchoredObject: flower,
+          anchor: anchor
+        });
 
         // For performance reasons if we add too many objects start
         // removing the oldest ones to keep the scene complexity
         // from growing too much.
-        if (flowers.length > MAX_FLOWERS) {
-          let oldFlower = flowers.shift();
-          scene.removeNode(oldFlower);
+        if (anchoredObjects.length > MAX_ANCHORED_OBJECTS) {
+          let objectToRemove = anchoredObjects.shift();
+          scene.removeNode(objectToRemove.anchoredObject);
+          objectToRemove.anchor.delete();
         }
       }
 
@@ -179,10 +182,12 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       let rayDirection = vec3.create();
       function onSelect(event) {
         if (reticle.visible) {
-          // The reticle should already be positioned at the latest hit point, 
-          // so we can just use it's matrix to save an unnecessary call to 
-          // event.frame.getHitTestResults.
-          addARObjectAt(reticle.matrix);
+          // Create an anchor.
+          reticleHitTestResult.createAnchor().then((anchor) => {
+            addAnchoredObjectsToScene(anchor);
+          }, (error) => {
+            console.error("Could not create anchor: " + error);
+          });
         }
       }
 
@@ -201,7 +206,18 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             let pose = hitTestResults[0].getPose(xrRefSpace);
             reticle.visible = true;
             reticle.matrix = pose.transform.matrix;
+            reticleHitTestResult = hitTestResults[0];
           }
+        }
+
+        for (const {anchoredObject, anchor} of anchoredObjects) {
+          // only update the object's position if it's still in the list
+          // of frame.trackedAnchors
+          if (!frame.trackedAnchors.has(anchor)) {
+            continue;
+          }
+          const anchorPose = frame.getPose(anchor.anchorSpace, xrRefSpace);
+          anchoredObject.matrix = anchorPose.transform.matrix;
         }
 
         scene.startFrame();

--- a/hit-test.html
+++ b/hit-test.html
@@ -1,17 +1,14 @@
 <!doctype html>
 <!--
 Copyright 2018 The Immersive Web Community Group
-
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
 the Software without restriction, including without limitation the rights to
 use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
 the Software, and to permit persons to whom the Software is furnished to do so,
 subject to the following conditions:
-
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
-
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
 FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
@@ -73,7 +70,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       let reticle = new Gltf2Node({url: 'media/gltf/reticle/reticle.gltf'});
       reticle.visible = false;
       scene.addNode(reticle);
-      let reticleHitTestResult = null;
 
       // Having a really simple drop shadow underneath an object helps ground
       // it in the world without adding much complexity.
@@ -106,7 +102,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       }
 
       function onRequestSession() {
-        return navigator.xr.requestSession('immersive-ar', {requiredFeatures: ['local', 'hit-test', 'anchors']})
+        return navigator.xr.requestSession('immersive-ar', {requiredFeatures: ['local', 'hit-test']})
                            .then((session) => {
           xrButton.setSession(session);
           onSessionStarted(session);
@@ -148,7 +144,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       }
 
       function onEndSession(session) {
-        anchoredObjects.clear();
         xrHitTestSource.cancel();
         xrHitTestSource = null;
         session.end();
@@ -158,23 +153,22 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         xrButton.setSession(null);
       }
 
-      const MAX_ANCHORED_OBJECTS = 30;
-      let anchoredObjects = [];
-      function addAnchoredObjectsToScene(anchor) {
-        let flower = new Gltf2Node({url: 'media/gltf/sunflower/sunflower.gltf'});
-        scene.addNode(flower);
-        anchoredObjects.push({
-          anchoredObject: flower,
-          anchor: anchor
-        });
+      // Adds a new object to the scene at the
+      // specified transform.
+      function addARObjectAt(matrix) {
+        let newFlower = arObject.clone();
+        newFlower.visible = true;
+        newFlower.matrix = matrix;
+        scene.addNode(newFlower);
+
+        flowers.push(newFlower);
 
         // For performance reasons if we add too many objects start
         // removing the oldest ones to keep the scene complexity
         // from growing too much.
-        if (anchoredObjects.length > MAX_ANCHORED_OBJECTS) {
-          let objectToRemove = anchoredObjects.shift();
-          scene.removeNode(objectToRemove.anchoredObject);
-          objectToRemove.anchor.delete();
+        if (flowers.length > MAX_FLOWERS) {
+          let oldFlower = flowers.shift();
+          scene.removeNode(oldFlower);
         }
       }
 
@@ -182,12 +176,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       let rayDirection = vec3.create();
       function onSelect(event) {
         if (reticle.visible) {
-          // Create an anchor.
-          reticleHitTestResult.createAnchor().then((anchor) => {
-            addAnchoredObjectsToScene(anchor);
-          }, (error) => {
-            console.error("Could not create anchor: " + error);
-          });
+          // The reticle should already be positioned at the latest hit point, 
+          // so we can just use it's matrix to save an unnecessary call to 
+          // event.frame.getHitTestResults.
+          addARObjectAt(reticle.matrix);
         }
       }
 
@@ -206,18 +198,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             let pose = hitTestResults[0].getPose(xrRefSpace);
             reticle.visible = true;
             reticle.matrix = pose.transform.matrix;
-            reticleHitTestResult = hitTestResults[0];
           }
-        }
-
-        for (const {anchoredObject, anchor} of anchoredObjects) {
-          // only update the object's position if it's still in the list
-          // of frame.trackedAnchors
-          if (!frame.trackedAnchors.has(anchor)) {
-            continue;
-          }
-          const anchorPose = frame.getPose(anchor.anchorSpace, xrRefSpace);
-          anchoredObject.matrix = anchorPose.transform.matrix;
         }
 
         scene.startFrame();

--- a/index.html
+++ b/index.html
@@ -227,7 +227,11 @@
 
             { title: 'Hit Test', category: 'AR Basics',
               path: 'hit-test.html',
-              description: 'Demonstrates using the Hit Test API together with Anchors API to place virtual objects on real-world surfaces.'},
+              description: 'Demonstrates using the Hit Test API to place virtual objects on real-world surfaces.'},
+              
+            { title: 'Hit Test with Anchors', category: 'AR Basics',
+              path: 'hit-test-anchors.html',
+              description: 'Demonstrates using the Hit Test API together with the Anchors API to place virtual objects on real-world surfaces.'},
 
             { tag: 'hr' },
             { tag: 'br' },

--- a/index.html
+++ b/index.html
@@ -227,7 +227,7 @@
 
             { title: 'Hit Test', category: 'AR Basics',
               path: 'hit-test.html',
-              description: 'Demonstrates using the Hit Test API to place virtual objects on real-world surfaces.'},
+              description: 'Demonstrates using the Hit Test API together with Anchors API to place virtual objects on real-world surfaces.'},
 
             { tag: 'hr' },
             { tag: 'br' },


### PR DESCRIPTION
Anchor are mostly leveraged together with the hit-test. Thus, we should update the hittest sample to demonstrate the usage of Anchor and Hit-test together.