### PR TITLE
Fit fps string into 6 char boundary

### DIFF
--- a/js/render/nodes/stats-viewer.js
+++ b/js/render/nodes/stats-viewer.js
@@ -263,6 +263,6 @@ export class StatsViewer extends Node {
 
     this._lastSegment = (this._lastSegment+1) % SEGMENTS;
 
-    this._sevenSegmentNode.text = `${this._fpsAverage} FP5`;
+    this._sevenSegmentNode.text = `${this._fpsAverage.toString().padStart(3)}FP5`;
   }
 }


### PR DESCRIPTION
Now would display as:
1 fps => "1  FPS"
14 fps => "14 FPS"
144 fps => "144FPS"

I think sufficient not to have a space for 3-digit fps.

Fixes #147 

