### PR TITLE
Correctly add 'dom-overlay' to optionalFeatures in case of an 'immersive-ar' session

### DIFF
--- a/report/index.html
+++ b/report/index.html
@@ -457,7 +457,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
               };
 
               if (name == 'immersive-ar') {
-                optionalFeatures.push('dom-overlay');
+                sessionOptions.optionalFeatures.push('dom-overlay');
                 sessionOptions.domOverlay = { root: document.getElementById('session-report') };
               }
 


### PR DESCRIPTION
When trying out the report page on the Pico Browser of the Pico Neo3 Link, the 'Begin Session' button for `immersive-ar` did nothing. Hooking up a debugger showed an error that `optionalFeatures` was not defined. A quick look at the code revealed that it indeed attempts to add the `dom-overlay` directly to `optionalFeatures`, but this is part of the `sessionOptions`. This PR fixes that issue.