### PR TITLE
gl.stencilMask should not be set to a boolean

### DIFF
--- a/js/render/core/renderer.js
+++ b/js/render/core/renderer.js
@@ -985,7 +985,7 @@ export class Renderer {
 
       let stencilMaskChange = (state & CAP.STENCIL_MASK) - (prevState & CAP.STENCIL_MASK);
       if (stencilMaskChange) {
-        gl.stencilMask(stencilMaskChange > 1);
+        gl.stencilMask(stencilMaskChange > 1 ? 0xff : 0x00);
       }
     }
 


### PR DESCRIPTION
`gl.stencilMask` [expects a GLUint](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/stencilMask) as its parameter, not a boolean value. 

This is relevant for https://github.com/BabylonJS/Spector.js/pull/257; when running Spector.js on the webxr samples, captures would fail because Spector was expecting a numerical value in the `stencilMask` call and got a boolean instead.

I haven't dug super deep into the code, so am not entirely certain that the values I provided are the desired ones for the stencilMask call.