### PR TITLE
Fix: Added depthSensing key with usage and data format prefs

### DIFF
--- a/proposals/phone-ar-depth-gpu.html
+++ b/proposals/phone-ar-depth-gpu.html
@@ -102,6 +102,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
         let options = {
           requiredFeatures: ['depth-sensing'],
+          depthSensing: {
+            usagePreference: ["gpu-optimized", "cpu-optimized"],
+            dataFormatPreference: ["float32", "luminance-alpha"],
+          }
         };
 
         navigator.xr.requestSession('immersive-ar', options).then((session) => {

--- a/proposals/phone-ar-depth.html
+++ b/proposals/phone-ar-depth.html
@@ -102,6 +102,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
         let options = {
           requiredFeatures: ['depth-sensing'],
+          depthSensing: {
+            usagePreference: ["cpu-optimized", "gpu-optimized"],
+            dataFormatPreference: ["luminance-alpha", "float32"],
+          }
         };
 
         navigator.xr.requestSession('immersive-ar', options).then((session) => {


### PR DESCRIPTION
It seems the Chrome implementation has changed and it now follows https://www.w3.org/TR/webxr-depth-sensing-1/#session-configuration. 

Related:
- https://github.com/immersive-web/webxr-samples/issues/154

So a new key is needed for the session to even start.
This PR adds that - and the session starts due to that - but I'm not sure how to change the sample to actually work again (right now I see nothing about the depth).

Help appreciated!