### PR TITLE
add reset event to room-scale sample

### DIFF
--- a/room-scale.html
+++ b/room-scale.html
@@ -165,6 +165,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             } else {
               boundsRenderer.boundedRefSpace = refSpace;
             }
+
+            refSpace.onreset = (evt) => {
+              boundsRenderer.boundedRefSpace = evt.referenceSpace;
+            }
           }).catch(() => {
             // If a bounded reference space isn't supported, fall back to a
             // local-floor reference space. This still provides a floor-relative


### PR DESCRIPTION
We didn't listen to the reset event on the bounded floor so we never updated to the correct guardian bounds