### PR TITLE
fix anchor sample: anchor creation timing

### DIFF
--- a/anchors.html
+++ b/anchors.html
@@ -252,12 +252,14 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           });
 
           tracked_anchors.forEach(anchor => {
-            const anchorPose = frame.getPose(anchor.anchorSpace, xrRefSpace);
-            if (anchorPose) {
-              anchor.context.sceneObject.matrix = anchorPose.transform.matrix;
-              anchor.context.sceneObject.visible = true;
-            } else {
-              anchor.context.sceneObject.visible = false;
+            if (anchor.context) {
+              const anchorPose = frame.getPose(anchor.anchorSpace, xrRefSpace);
+              if (anchorPose) {
+                anchor.context.sceneObject.matrix = anchorPose.transform.matrix;
+                anchor.context.sceneObject.visible = true;
+              } else {
+                anchor.context.sceneObject.visible = false;
+              }
             }
           });
 


### PR DESCRIPTION
According to https://immersive-web.github.io/anchors/#anchor-updates
when an anchor is created, during the next "update anchor" task:
1. Anchor is added to the `trackedAnchors` set on the frame
2. The anchor creation promise will be resolved, and the entry removed from the list of new anchors in session

This sample makes the assumption that when iterate through the trackedAnchors on every frame, the anchor context already exists. This is incorrect.

the `context` is created in `addAnchoredObjectToScene`, which runs after the anchor creation promise resolves (not immediately, but executed asynchronously in the next microtask queue). It is possible that when iterating through the trackedAnchors on frame, the `addAnchoredObjectToScene` has not executed yet, and the `context` object won't exist, causing the logic to crash.