### PR TITLE
Don't request 'layers' feature in projection layer sample

### DIFF
--- a/layers-samples/proj-layer.html
+++ b/layers-samples/proj-layer.html
@@ -97,9 +97,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
     function onRequestSession() {
       if (!xrSession) {
-        navigator.xr.requestSession('immersive-vr', {
-          requiredFeatures: ['layers'],
-        }).then(onSessionStarted);
+        // Unlike all other layer types, use of a single projection layer does
+        // not require the 'layers' feature.
+        navigator.xr.requestSession('immersive-vr').then(onSessionStarted);
       } else {
         onEndSession();
       }


### PR DESCRIPTION
While doing some testing I noticed that we didn't have any samples that utilized a projection layer without requesting the `layers` feature. Seems appropriate that the first layers sample could cover that case, since all other layers samples require it. What do you think, @cabanier?