### PR TITLE
Use original chess-pano-4k180.jpg which has left view on top of right view

### DIFF
--- a/layers-samples/eqrt-layer.html
+++ b/layers-samples/eqrt-layer.html
@@ -70,7 +70,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     const EQRT_TEXTURE_MONO_PATH = '../media/textures/mono_equirect_test.png';
     const EQRT_180_TEXTURE_MONO_PATH = '../media/textures/mono-equirect180.png';
     const EQRT_TEXTURE_STEREO_PATH = '../media/textures/chess-pano-4k.png';
-    const EQRT_180_TEXTURE_STEREO_PATH = '../media/textures/chess-pano-4k180.png';
+    const EQRT_180_TEXTURE_STEREO_PATH = '../media/textures/chess-pano-4k180.jpg';
 
     // If requested, use the polyfill to provide support for mobile devices
     // and devices which only support WebVR.


### PR DESCRIPTION
Fixes #132 

PR #211 partially fixed #132 by updating the `chess-pano-4k.png` image, ensuring the left view is on top of the right view. The 180 degree variant was left unchanged, but exhibits the same issue (right view is on top).

This PR simply removes the incorrectly modified `chess-pano-4k180.png` image and reverts the reference to the original  `chess-pano-4k180.jpg`, [as it's still in the repository](https://github.com/immersive-web/webxr-samples/blob/main/media/textures/chess-pano-4k180.jpg). There doesn't seem to be an upside to using `.png`, as the originals were jpegs to begin with, and is considerably larger (9.11MB vs 1.39MB).