### PR TITLE
Improve WebGPU XR benchmark rendering and controller support

### DIFF
--- a/js/render/core/renderer-gpu.js
+++ b/js/render/core/renderer-gpu.js
@@ -342,9 +342,9 @@ class GPURenderMaterial {
 // Byte sizes for uniform buffer layout (std140-aligned).
 // Frame uniforms: projection(64) + view(64) + lightDir(16) + lightColor(16) + cameraPos(16) = 176
 const FRAME_UNIFORM_SIZE = 176;
-// Multiview frame uniforms: 2 projection matrices, 2 view matrices,
-// lightDir, lightColor, and 2 vec4 camera positions = 320
-const VIEW_INSTANCING_FRAME_UNIFORM_SIZE = 320;
+// Multiview frame uniforms: 2 view-projection matrices, 2 projection matrices,
+// 2 view matrices, lightDir, lightColor, and 2 vec4 camera positions = 448
+const VIEW_INSTANCING_FRAME_UNIFORM_SIZE = 448;
 // Model uniforms: modelMatrix(64)
 const MODEL_UNIFORM_SIZE = 64;
 // Material uniforms: baseColorFactor(16) + metallicRoughnessFactor(8+pad8) + emissiveFactor(12+pad4) + occlusionStrength(4+pad12) = 64
@@ -363,6 +363,7 @@ const STANDARD_FRAME_UNIFORM_WGSL = `struct FrameUniforms {
 };`;
 
 const VIEW_INSTANCING_FRAME_UNIFORM_WGSL = `struct FrameUniforms {
+  viewProjectionMatrices: array<mat4x4f, 2>,
   projectionMatrices: array<mat4x4f, 2>,
   viewMatrices: array<mat4x4f, 2>,
   lightDirection: vec3f,
@@ -392,6 +393,9 @@ function applyViewInstancingToWgsl(source, wgslEnable) {
   if (output.includes(STANDARD_FRAME_UNIFORM_WGSL)) {
     output = output
         .replace(STANDARD_FRAME_UNIFORM_WGSL, VIEW_INSTANCING_FRAME_UNIFORM_WGSL)
+        .replaceAll(
+            'frame.projectionMatrix * frame.viewMatrix *',
+            'frame.viewProjectionMatrices[viewIndex] *')
         .replaceAll('frame.projectionMatrix', 'frame.projectionMatrices[viewIndex]')
         .replaceAll('frame.viewMatrix', 'frame.viewMatrices[viewIndex]')
         .replaceAll('frame.cameraPosition', 'frame.cameraPositions[viewIndex].xyz');
@@ -406,7 +410,7 @@ function applyViewInstancingToWgsl(source, wgslEnable) {
 
   return output.replace(
       'fn vs_main(input: VertexInput) -> VertexOutput {\n',
-      'fn vs_main(input: VertexInput, @builtin(view_index) rawViewIndex: u32) -> VertexOutput {\n  let viewIndex = min(rawViewIndex, 1u);\n');
+      'fn vs_main(input: VertexInput, @builtin(view_index) rawViewIndex: u32) -> VertexOutput {\n  let viewIndex = rawViewIndex;\n');
 }
 
 function vertexFormatForAttribute(attribute) {
@@ -430,6 +434,11 @@ export class GPURenderer {
     this._viewInstancing = !!options.viewInstancing;
     this._viewInstancingWgslEnable =
         options.viewInstancingWgslEnable || 'view_instancing';
+    this._transientMsaaAttachments =
+        !this._viewInstancing ||
+        !!getSupportedGPUFeature(
+            device.features,
+            MULTISAMPLED_ARRAY_TEXTURE_FEATURES);
     this._frameUniformSize = this._viewInstancing ?
         VIEW_INSTANCING_FRAME_UNIFORM_SIZE :
         FRAME_UNIFORM_SIZE;
@@ -439,6 +448,7 @@ export class GPURenderer {
     this._textureCache = {};
     this._msaaColorAttachments = [];
     this._msaaDepthAttachments = [];
+    this._viewProjectionMatrices = [mat4.create(), mat4.create()];
     this._renderPrimitives = Array(RENDER_ORDER.DEFAULT);
     this._cameraPositions = [];
 
@@ -580,11 +590,16 @@ export class GPURenderer {
       attachment.texture.destroy();
     }
 
+    let usage = GPUTextureUsage.RENDER_ATTACHMENT;
+    if (GPUTextureUsage.TRANSIENT_ATTACHMENT && this._transientMsaaAttachments) {
+      usage |= GPUTextureUsage.TRANSIENT_ATTACHMENT;
+    }
+
     let texture = this._device.createTexture({
       size: [width, height, depthOrArrayLayers],
       sampleCount: this._sampleCount,
       format: format,
-      usage: GPUTextureUsage.RENDER_ATTACHMENT,
+      usage: usage,
     });
     attachment = {
       texture,
@@ -995,12 +1010,17 @@ export class GPURenderer {
     frameData.fill(0);
     const viewCount = Math.min(views.length, MAX_VIEW_INSTANCE_COUNT);
     for (let i = 0; i < viewCount; ++i) {
-      frameData.set(views[i].projectionMatrix, i * 16);
-      frameData.set(views[i].viewMatrix, 32 + i * 16);
-      frameData.set(this._cameraPositions[i], 72 + i * 4);
+      mat4.multiply(
+          this._viewProjectionMatrices[i],
+          views[i].projectionMatrix,
+          views[i].viewMatrix);
+      frameData.set(this._viewProjectionMatrices[i], i * 16);
+      frameData.set(views[i].projectionMatrix, 32 + i * 16);
+      frameData.set(views[i].viewMatrix, 64 + i * 16);
+      frameData.set(this._cameraPositions[i], 104 + i * 4);
     }
-    frameData.set(this._globalLightDir, 64);
-    frameData.set(this._globalLightColor, 68);
+    frameData.set(this._globalLightDir, 96);
+    frameData.set(this._globalLightColor, 100);
     this._device.queue.writeBuffer(frameUniform.buffer, 0, frameData);
   }
 

--- a/js/render/core/renderer-gpu.js
+++ b/js/render/core/renderer-gpu.js
@@ -309,6 +309,16 @@ const MODEL_UNIFORM_SIZE = 64;
 // Material uniforms: baseColorFactor(16) + metallicRoughnessFactor(8+pad8) + emissiveFactor(12+pad4) + occlusionStrength(4+pad12) = 64
 const MATERIAL_UNIFORM_SIZE = 64;
 
+function vertexFormatForAttribute(attribute) {
+  switch (attribute._componentCount) {
+    case 1: return 'float32';
+    case 2: return 'float32x2';
+    case 3: return 'float32x3';
+    case 4: return 'float32x4';
+  }
+  throw new Error(`Unsupported vertex component count: ${attribute._componentCount}`);
+}
+
 export class GPURenderer {
   constructor(device, colorFormat, options = {}) {
     options = typeof options == 'number' ? {sampleCount: options} : options;
@@ -618,13 +628,7 @@ export class GPURenderer {
     let layouts = [];
     for (let ab of renderPrimitive._attributeBuffers) {
       let a = ab.attrib;
-      let format;
-      switch (a._componentCount) {
-        case 1: format = 'float32'; break;
-        case 2: format = 'float32x2'; break;
-        case 3: format = 'float32x3'; break;
-        case 4: format = 'float32x4'; break;
-      }
+      let format = vertexFormatForAttribute(a);
       layouts.push({
         arrayStride: a._stride || (a._componentCount * 4),
         attributes: [{
@@ -637,8 +641,20 @@ export class GPURenderer {
     return layouts;
   }
 
+  _vertexBufferLayoutKeyForPrimitive(renderPrimitive) {
+    return renderPrimitive._attributeBuffers.map((ab) => {
+      let a = ab.attrib;
+      let stride = a._stride || (a._componentCount * 4);
+      let format = vertexFormatForAttribute(a);
+      return `${a._attribIndex}:${format}:${stride}:${a._byteOffset}`;
+    }).join('|');
+  }
+
   _getOrCreatePipeline(renderPrimitive, renderMaterial) {
-    let key = `${renderPrimitive._attributeMask}:${renderMaterial._state}:${renderMaterial._materialName}:${this._sampleCount}`;
+    // WebGPU pipelines bake vertex buffer layouts, so primitives with the same
+    // attribute mask but different buffer slot order need distinct pipelines.
+    let vertexLayoutKey = this._vertexBufferLayoutKeyForPrimitive(renderPrimitive);
+    let key = `${renderPrimitive._attributeMask}:${vertexLayoutKey}:${renderMaterial._state}:${renderMaterial._materialName}:${this._sampleCount}`;
     if (key in this._pipelineCache) {
       return this._pipelineCache[key];
     }

--- a/js/render/core/renderer-gpu.js
+++ b/js/render/core/renderer-gpu.js
@@ -67,6 +67,29 @@ const GL_DEPTH_FUNC_TO_GPU = [
   'greater', 'not-equal', 'greater-equal', 'always'
 ];
 
+export const VIEW_INSTANCING_FEATURES = [
+  {feature: 'view-instancing', wgslEnable: 'view_instancing'},
+  {
+    feature: 'chromium-experimental-multiview',
+    wgslEnable: 'chromium_experimental_multiview',
+  },
+];
+
+export const MULTISAMPLED_ARRAY_TEXTURE_FEATURES = [
+  'multisampled-array-textures',
+  'chromium-experimental-multisampled-array-textures',
+];
+
+export function getSupportedGPUFeature(features, candidates) {
+  for (let candidate of candidates) {
+    const feature = typeof candidate == 'string' ? candidate : candidate.feature;
+    if (features && features.has(feature)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
 // Creates a WebGPU device with XR compatibility.
 export async function createWebGPUContext(options) {
   if (!navigator.gpu) {
@@ -82,7 +105,22 @@ export async function createWebGPUContext(options) {
     return null;
   }
 
-  const device = await adapter.requestDevice();
+  const requiredFeatures = [];
+  for (let feature of options?.requiredFeatures || []) {
+    if (!adapter.features.has(feature)) {
+      throw new Error(`Required WebGPU feature is not supported: ${feature}`);
+    }
+    requiredFeatures.push(feature);
+  }
+
+  for (let feature of options?.optionalFeatures || []) {
+    if (adapter.features.has(feature) && !requiredFeatures.includes(feature)) {
+      requiredFeatures.push(feature);
+    }
+  }
+
+  const deviceDescriptor = requiredFeatures.length ? {requiredFeatures} : {};
+  const device = await adapter.requestDevice(deviceDescriptor);
   return device;
 }
 
@@ -304,10 +342,72 @@ class GPURenderMaterial {
 // Byte sizes for uniform buffer layout (std140-aligned).
 // Frame uniforms: projection(64) + view(64) + lightDir(16) + lightColor(16) + cameraPos(16) = 176
 const FRAME_UNIFORM_SIZE = 176;
+// Multiview frame uniforms: 2 projection matrices, 2 view matrices,
+// lightDir, lightColor, and 2 vec4 camera positions = 320
+const VIEW_INSTANCING_FRAME_UNIFORM_SIZE = 320;
 // Model uniforms: modelMatrix(64)
 const MODEL_UNIFORM_SIZE = 64;
 // Material uniforms: baseColorFactor(16) + metallicRoughnessFactor(8+pad8) + emissiveFactor(12+pad4) + occlusionStrength(4+pad12) = 64
 const MATERIAL_UNIFORM_SIZE = 64;
+const MAX_VIEW_INSTANCE_COUNT = 2;
+
+const STANDARD_FRAME_UNIFORM_WGSL = `struct FrameUniforms {
+  projectionMatrix: mat4x4f,
+  viewMatrix: mat4x4f,
+  lightDirection: vec3f,
+  _pad0: f32,
+  lightColor: vec3f,
+  _pad1: f32,
+  cameraPosition: vec3f,
+  _pad2: f32,
+};`;
+
+const VIEW_INSTANCING_FRAME_UNIFORM_WGSL = `struct FrameUniforms {
+  projectionMatrices: array<mat4x4f, 2>,
+  viewMatrices: array<mat4x4f, 2>,
+  lightDirection: vec3f,
+  _pad0: f32,
+  lightColor: vec3f,
+  _pad1: f32,
+  cameraPositions: array<vec4f, 2>,
+};`;
+
+const MOTION_FRAME_UNIFORM_WGSL = `struct FrameUniforms {
+  projectionMatrix: mat4x4f,
+  viewMatrix: mat4x4f,
+  previousProjectionMatrix: mat4x4f,
+  previousViewMatrix: mat4x4f,
+};`;
+
+const VIEW_INSTANCING_MOTION_FRAME_UNIFORM_WGSL = `struct FrameUniforms {
+  projectionMatrices: array<mat4x4f, 2>,
+  viewMatrices: array<mat4x4f, 2>,
+  previousProjectionMatrices: array<mat4x4f, 2>,
+  previousViewMatrices: array<mat4x4f, 2>,
+};`;
+
+function applyViewInstancingToWgsl(source, wgslEnable) {
+  let output = `enable ${wgslEnable};\n` + source;
+
+  if (output.includes(STANDARD_FRAME_UNIFORM_WGSL)) {
+    output = output
+        .replace(STANDARD_FRAME_UNIFORM_WGSL, VIEW_INSTANCING_FRAME_UNIFORM_WGSL)
+        .replaceAll('frame.projectionMatrix', 'frame.projectionMatrices[viewIndex]')
+        .replaceAll('frame.viewMatrix', 'frame.viewMatrices[viewIndex]')
+        .replaceAll('frame.cameraPosition', 'frame.cameraPositions[viewIndex].xyz');
+  } else if (output.includes(MOTION_FRAME_UNIFORM_WGSL)) {
+    output = output
+        .replace(MOTION_FRAME_UNIFORM_WGSL, VIEW_INSTANCING_MOTION_FRAME_UNIFORM_WGSL)
+        .replaceAll('frame.previousProjectionMatrix', 'frame.previousProjectionMatrices[viewIndex]')
+        .replaceAll('frame.previousViewMatrix', 'frame.previousViewMatrices[viewIndex]')
+        .replaceAll('frame.projectionMatrix', 'frame.projectionMatrices[viewIndex]')
+        .replaceAll('frame.viewMatrix', 'frame.viewMatrices[viewIndex]');
+  }
+
+  return output.replace(
+      'fn vs_main(input: VertexInput) -> VertexOutput {\n',
+      'fn vs_main(input: VertexInput, @builtin(view_index) rawViewIndex: u32) -> VertexOutput {\n  let viewIndex = min(rawViewIndex, 1u);\n');
+}
 
 function vertexFormatForAttribute(attribute) {
   switch (attribute._componentCount) {
@@ -327,6 +427,12 @@ export class GPURenderer {
     this._colorFormat = colorFormat || 'rgba8unorm';
     this._depthFormat = 'depth24plus';
     this._sampleCount = options.sampleCount > 1 ? 4 : 1;
+    this._viewInstancing = !!options.viewInstancing;
+    this._viewInstancingWgslEnable =
+        options.viewInstancingWgslEnable || 'view_instancing';
+    this._frameUniformSize = this._viewInstancing ?
+        VIEW_INSTANCING_FRAME_UNIFORM_SIZE :
+        FRAME_UNIFORM_SIZE;
     this._frameId = 0;
     this._pipelineCache = {};
     this._shaderCache = {};
@@ -363,7 +469,7 @@ export class GPURenderer {
     // Frame uniforms are double-buffered by view so both eyes can be encoded
     // into one command buffer without racing on the same uniform contents.
     this._frameUniforms = [];
-    this._frameData = new Float32Array(FRAME_UNIFORM_SIZE / 4);
+    this._frameData = new Float32Array(this._frameUniformSize / 4);
 
     // Create the frame bind group layout (group 0).
     this._frameBindGroupLayout = device.createBindGroupLayout({
@@ -416,7 +522,7 @@ export class GPURenderer {
     }
 
     let buffer = this._device.createBuffer({
-      size: FRAME_UNIFORM_SIZE,
+      size: this._frameUniformSize,
       usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
     });
     let bindGroup = this._device.createBindGroup({
@@ -451,12 +557,21 @@ export class GPURenderer {
     return modelUniform;
   }
 
-  _getMsaaAttachment(attachments, viewIndex, width, height, format) {
+  _getMsaaAttachment(
+      attachments,
+      viewIndex,
+      width,
+      height,
+      format,
+      depthOrArrayLayers = 1,
+      viewDimension = '2d') {
     let attachment = attachments[viewIndex];
     if (attachment &&
         attachment.width == width &&
         attachment.height == height &&
         attachment.format == format &&
+        attachment.depthOrArrayLayers == depthOrArrayLayers &&
+        attachment.viewDimension == viewDimension &&
         attachment.sampleCount == this._sampleCount) {
       return attachment;
     }
@@ -466,17 +581,23 @@ export class GPURenderer {
     }
 
     let texture = this._device.createTexture({
-      size: [width, height],
+      size: [width, height, depthOrArrayLayers],
       sampleCount: this._sampleCount,
       format: format,
       usage: GPUTextureUsage.RENDER_ATTACHMENT,
     });
     attachment = {
       texture,
-      view: texture.createView(),
+      view: texture.createView({
+        dimension: viewDimension,
+        baseArrayLayer: 0,
+        arrayLayerCount: depthOrArrayLayers,
+      }),
       width,
       height,
       format,
+      depthOrArrayLayers,
+      viewDimension,
       sampleCount: this._sampleCount,
     };
     attachments[viewIndex] = attachment;
@@ -604,7 +725,11 @@ export class GPURenderer {
   }
 
   _getShaderModule(material, renderPrimitive) {
-    let defines = material.getProgramDefines(renderPrimitive);
+    let defines = material.getProgramDefines(renderPrimitive) || {};
+    if (this._viewInstancing) {
+      defines['VIEW_INSTANCING'] = 1;
+      defines['VIEW_INSTANCING_WGSL_ENABLE'] = this._viewInstancingWgslEnable;
+    }
     let key = `${material.materialName}:${JSON.stringify(defines)}`;
 
     if (key in this._shaderCache) {
@@ -615,6 +740,11 @@ export class GPURenderer {
     if (!wgslSource) {
       console.error('Material does not provide WGSL source. Use a GPU-compatible material (e.g., PbrGPUMaterial).');
       return null;
+    }
+    if (this._viewInstancing) {
+      wgslSource = applyViewInstancingToWgsl(
+          wgslSource,
+          this._viewInstancingWgslEnable);
     }
 
     let module = this._device.createShaderModule({
@@ -654,7 +784,7 @@ export class GPURenderer {
     // WebGPU pipelines bake vertex buffer layouts, so primitives with the same
     // attribute mask but different buffer slot order need distinct pipelines.
     let vertexLayoutKey = this._vertexBufferLayoutKeyForPrimitive(renderPrimitive);
-    let key = `${renderPrimitive._attributeMask}:${vertexLayoutKey}:${renderMaterial._state}:${renderMaterial._materialName}:${this._sampleCount}`;
+    let key = `${renderPrimitive._attributeMask}:${vertexLayoutKey}:${renderMaterial._state}:${renderMaterial._materialName}:${this._sampleCount}:${this._viewInstancing}`;
     if (key in this._pipelineCache) {
       return this._pipelineCache[key];
     }
@@ -842,25 +972,69 @@ export class GPURenderer {
       this._cameraPositions[i][2] = p.z;
     }
 
+    if (this._viewInstancing) {
+      this._drawViewInstanced(views);
+      return;
+    }
+
+    this._drawViewsOneByOne(views);
+  }
+
+  _writeFrameUniformForView(view, viewIndex, frameUniform) {
+    let frameData = this._frameData;
+    frameData.set(view.projectionMatrix, 0);    // offset 0: projection (16 floats)
+    frameData.set(view.viewMatrix, 16);          // offset 64: view (16 floats)
+    frameData.set(this._globalLightDir, 32);     // offset 128: lightDir (3 floats)
+    frameData.set(this._globalLightColor, 36);   // offset 144: lightColor (3 floats)
+    frameData.set(this._cameraPositions[viewIndex], 40); // offset 160: cameraPos (3 floats)
+    this._device.queue.writeBuffer(frameUniform.buffer, 0, frameData);
+  }
+
+  _writeViewInstancingFrameUniform(views, frameUniform) {
+    let frameData = this._frameData;
+    frameData.fill(0);
+    const viewCount = Math.min(views.length, MAX_VIEW_INSTANCE_COUNT);
+    for (let i = 0; i < viewCount; ++i) {
+      frameData.set(views[i].projectionMatrix, i * 16);
+      frameData.set(views[i].viewMatrix, 32 + i * 16);
+      frameData.set(this._cameraPositions[i], 72 + i * 4);
+    }
+    frameData.set(this._globalLightDir, 64);
+    frameData.set(this._globalLightColor, 68);
+    this._device.queue.writeBuffer(frameUniform.buffer, 0, frameData);
+  }
+
+  _encodeRenderPrimitives(passEncoder) {
+    for (let renderPrimitives of this._renderPrimitives) {
+      if (renderPrimitives && renderPrimitives.length) {
+        this._drawPrimitives(passEncoder, renderPrimitives);
+      }
+    }
+  }
+
+  _drawViewsOneByOne(views) {
     let commandEncoder = this._device.createCommandEncoder();
     let encodedPass = false;
 
     // For XR, we render one view at a time (each into a different texture array layer).
     for (let vi = 0; vi < views.length; vi++) {
       let view = views[vi];
-      if (!view._colorView || !view._depthView) continue;
+      if (!view._colorView) continue;
 
       let colorView = view._colorView;
       let resolveTarget = undefined;
       let depthView = view._depthView;
       let colorStoreOp = 'store';
-      if (this._sampleCount > 1) {
-        let attachmentSize = this._getViewAttachmentSize(view);
+      let attachmentSize = null;
+      if (this._sampleCount > 1 || !depthView) {
+        attachmentSize = this._getViewAttachmentSize(view);
         if (!attachmentSize) {
-          console.warn('Skipping MSAA view because no viewport size is available.');
+          console.warn('Skipping view because no depth attachment or viewport size is available.');
           continue;
         }
+      }
 
+      if (this._sampleCount > 1) {
         colorView =
             this._getMsaaAttachment(
                 this._msaaColorAttachments,
@@ -877,17 +1051,19 @@ export class GPURenderer {
                 this._depthFormat).view;
         resolveTarget = view._colorView;
         colorStoreOp = 'discard';
+      } else if (!depthView) {
+        depthView =
+            this._getMsaaAttachment(
+                this._msaaDepthAttachments,
+                vi,
+                attachmentSize.width,
+                attachmentSize.height,
+                this._depthFormat).view;
       }
 
       // Update frame uniforms for this view.
-      let frameData = this._frameData;
-      frameData.set(view.projectionMatrix, 0);    // offset 0: projection (16 floats)
-      frameData.set(view.viewMatrix, 16);          // offset 64: view (16 floats)
-      frameData.set(this._globalLightDir, 32);     // offset 128: lightDir (3 floats)
-      frameData.set(this._globalLightColor, 36);   // offset 144: lightColor (3 floats)
-      frameData.set(this._cameraPositions[vi], 40); // offset 160: cameraPos (3 floats)
       let frameUniform = this._getFrameUniform(vi);
-      this._device.queue.writeBuffer(frameUniform.buffer, 0, frameData);
+      this._writeFrameUniformForView(view, vi, frameUniform);
 
       let passEncoder = commandEncoder.beginRenderPass({
         colorAttachments: [{
@@ -911,13 +1087,7 @@ export class GPURenderer {
       }
 
       passEncoder.setBindGroup(0, frameUniform.bindGroup);
-
-      // Draw all render primitives.
-      for (let renderPrimitives of this._renderPrimitives) {
-        if (renderPrimitives && renderPrimitives.length) {
-          this._drawPrimitives(passEncoder, renderPrimitives);
-        }
-      }
+      this._encodeRenderPrimitives(passEncoder);
 
       passEncoder.end();
       encodedPass = true;
@@ -926,6 +1096,90 @@ export class GPURenderer {
     if (encodedPass) {
       this._device.queue.submit([commandEncoder.finish()]);
     }
+  }
+
+  _drawViewInstanced(views) {
+    let view = views[0];
+    if (!view._colorView) return;
+
+    const viewCount = Math.min(views.length, MAX_VIEW_INSTANCE_COUNT);
+    let colorView = view._colorView;
+    let resolveTarget = undefined;
+    let depthView = view._depthView;
+    let colorStoreOp = 'store';
+    let attachmentSize = null;
+    if (this._sampleCount > 1 || !depthView) {
+      attachmentSize = this._getViewAttachmentSize(view);
+      if (!attachmentSize) {
+        console.warn('Skipping multiview because no depth attachment or viewport size is available.');
+        return;
+      }
+    }
+
+    if (this._sampleCount > 1) {
+      colorView =
+          this._getMsaaAttachment(
+              this._msaaColorAttachments,
+              0,
+              attachmentSize.width,
+              attachmentSize.height,
+              this._colorFormat,
+              viewCount,
+              '2d-array').view;
+      depthView =
+          this._getMsaaAttachment(
+              this._msaaDepthAttachments,
+              0,
+              attachmentSize.width,
+              attachmentSize.height,
+              this._depthFormat,
+              viewCount,
+              '2d-array').view;
+      resolveTarget = view._colorView;
+      colorStoreOp = 'discard';
+    } else if (!depthView) {
+      depthView =
+          this._getMsaaAttachment(
+              this._msaaDepthAttachments,
+              0,
+              attachmentSize.width,
+              attachmentSize.height,
+              this._depthFormat,
+              viewCount,
+              '2d-array').view;
+    }
+
+    let frameUniform = this._getFrameUniform(0);
+    this._writeViewInstancingFrameUniform(views, frameUniform);
+
+    let commandEncoder = this._device.createCommandEncoder();
+    let passEncoder = commandEncoder.beginRenderPass({
+      colorAttachments: [{
+        view: colorView,
+        resolveTarget: resolveTarget,
+        loadOp: 'clear',
+        storeOp: colorStoreOp,
+        clearValue: { r: 0, g: 0, b: 0, a: 0 },
+      }],
+      depthStencilAttachment: depthView ? {
+        view: depthView,
+        depthLoadOp: 'clear',
+        depthClearValue: 1.0,
+        depthStoreOp: 'discard',
+      } : undefined,
+      viewCount: viewCount,
+    });
+
+    if (view.viewport) {
+      let vp = view.viewport;
+      passEncoder.setViewport(vp.x, vp.y, vp.width, vp.height, 0.0, 1.0);
+    }
+
+    passEncoder.setBindGroup(0, frameUniform.bindGroup);
+    this._encodeRenderPrimitives(passEncoder);
+
+    passEncoder.end();
+    this._device.queue.submit([commandEncoder.finish()]);
   }
 
   _drawPrimitives(passEncoder, renderPrimitives) {

--- a/js/render/core/renderer-gpu.js
+++ b/js/render/core/renderer-gpu.js
@@ -340,10 +340,10 @@ class GPURenderMaterial {
 }
 
 // Byte sizes for uniform buffer layout (std140-aligned).
-// Frame uniforms: projection(64) + view(64) + lightDir(16) + lightColor(16) + cameraPos(16) = 176
+// Frame uniforms: projection(64) + view(64) + cameraPos(16) + lightDir(16) + lightColor(16) = 176
 const FRAME_UNIFORM_SIZE = 176;
 // Multiview frame uniforms: 2 view-projection matrices, 2 projection matrices,
-// 2 view matrices, lightDir, lightColor, and 2 vec4 camera positions = 448
+// 2 view matrices, 2 vec4 camera positions, lightDir, and lightColor = 448
 const VIEW_INSTANCING_FRAME_UNIFORM_SIZE = 448;
 // Model uniforms: modelMatrix(64)
 const MODEL_UNIFORM_SIZE = 64;
@@ -354,23 +354,18 @@ const MAX_VIEW_INSTANCE_COUNT = 2;
 const STANDARD_FRAME_UNIFORM_WGSL = `struct FrameUniforms {
   projectionMatrix: mat4x4f,
   viewMatrix: mat4x4f,
-  lightDirection: vec3f,
-  _pad0: f32,
-  lightColor: vec3f,
-  _pad1: f32,
   cameraPosition: vec3f,
-  _pad2: f32,
+  lightDirection: vec3f,
+  lightColor: vec3f,
 };`;
 
 const VIEW_INSTANCING_FRAME_UNIFORM_WGSL = `struct FrameUniforms {
   viewProjectionMatrices: array<mat4x4f, 2>,
   projectionMatrices: array<mat4x4f, 2>,
   viewMatrices: array<mat4x4f, 2>,
-  lightDirection: vec3f,
-  _pad0: f32,
-  lightColor: vec3f,
-  _pad1: f32,
   cameraPositions: array<vec4f, 2>,
+  lightDirection: vec3f,
+  lightColor: vec3f,
 };`;
 
 const MOTION_FRAME_UNIFORM_WGSL = `struct FrameUniforms {
@@ -999,9 +994,9 @@ export class GPURenderer {
     let frameData = this._frameData;
     frameData.set(view.projectionMatrix, 0);    // offset 0: projection (16 floats)
     frameData.set(view.viewMatrix, 16);          // offset 64: view (16 floats)
-    frameData.set(this._globalLightDir, 32);     // offset 128: lightDir (3 floats)
-    frameData.set(this._globalLightColor, 36);   // offset 144: lightColor (3 floats)
-    frameData.set(this._cameraPositions[viewIndex], 40); // offset 160: cameraPos (3 floats)
+    frameData.set(this._cameraPositions[viewIndex], 32); // offset 128: cameraPos (3 floats)
+    frameData.set(this._globalLightDir, 36);     // offset 144: lightDir (3 floats)
+    frameData.set(this._globalLightColor, 40);   // offset 160: lightColor (3 floats)
     this._device.queue.writeBuffer(frameUniform.buffer, 0, frameData);
   }
 
@@ -1017,10 +1012,10 @@ export class GPURenderer {
       frameData.set(this._viewProjectionMatrices[i], i * 16);
       frameData.set(views[i].projectionMatrix, 32 + i * 16);
       frameData.set(views[i].viewMatrix, 64 + i * 16);
-      frameData.set(this._cameraPositions[i], 104 + i * 4);
+      frameData.set(this._cameraPositions[i], 96 + i * 4);
     }
-    frameData.set(this._globalLightDir, 96);
-    frameData.set(this._globalLightColor, 100);
+    frameData.set(this._globalLightDir, 104);
+    frameData.set(this._globalLightColor, 108);
     this._device.queue.writeBuffer(frameUniform.buffer, 0, frameData);
   }
 

--- a/js/render/loaders/gltf2-gpu.js
+++ b/js/render/loaders/gltf2-gpu.js
@@ -22,6 +22,7 @@ import {PbrGPUMaterial} from '../materials/pbr-gpu.js';
 import {Node} from '../core/node.js';
 import {Primitive, PrimitiveAttribute} from '../core/primitive.js';
 import {ImageTexture, ColorTexture} from '../core/texture.js';
+import {ATTRIB} from '../core/renderer-gpu.js';
 
 const GLB_MAGIC = 0x46546C67;
 const CHUNK_TYPE = {
@@ -230,6 +231,13 @@ export class Gltf2GPULoader {
         let max = null;
 
         for (let name in primitive.attributes) {
+          if (!(name in ATTRIB)) {
+            // The WebGPU renderer does not implement skinning or custom vertex
+            // attributes yet. Ignore streams such as JOINTS_0 and WEIGHTS_0
+            // instead of binding them to an undefined shader location.
+            continue;
+          }
+
           let accessor = accessors[primitive.attributes[name]];
           let bufferView = bufferViews[accessor.bufferView];
           elementCount = accessor.count;

--- a/js/render/materials/pbr-gpu.js
+++ b/js/render/materials/pbr-gpu.js
@@ -26,12 +26,9 @@ const WGSL_COMMON = `
 struct FrameUniforms {
   projectionMatrix: mat4x4f,
   viewMatrix: mat4x4f,
-  lightDirection: vec3f,
-  _pad0: f32,
-  lightColor: vec3f,
-  _pad1: f32,
   cameraPosition: vec3f,
-  _pad2: f32,
+  lightDirection: vec3f,
+  lightColor: vec3f,
 };
 @group(0) @binding(0) var<uniform> frame: FrameUniforms;
 

--- a/js/render/nodes/seven-segment-text-gpu.js
+++ b/js/render/nodes/seven-segment-text-gpu.js
@@ -33,12 +33,9 @@ const SEVEN_SEGMENT_WGSL = `
 struct FrameUniforms {
   projectionMatrix: mat4x4f,
   viewMatrix: mat4x4f,
-  lightDirection: vec3f,
-  _pad0: f32,
-  lightColor: vec3f,
-  _pad1: f32,
   cameraPosition: vec3f,
-  _pad2: f32,
+  lightDirection: vec3f,
+  lightColor: vec3f,
 };
 @group(0) @binding(0) var<uniform> frame: FrameUniforms;
 

--- a/js/render/nodes/skybox-gpu.js
+++ b/js/render/nodes/skybox-gpu.js
@@ -30,12 +30,9 @@ const WGSL_SOURCE = `
 struct FrameUniforms {
   projectionMatrix: mat4x4f,
   viewMatrix: mat4x4f,
-  lightDirection: vec3f,
-  _pad0: f32,
-  lightColor: vec3f,
-  _pad1: f32,
   cameraPosition: vec3f,
-  _pad2: f32,
+  lightDirection: vec3f,
+  lightColor: vec3f,
 };
 @group(0) @binding(0) var<uniform> frame: FrameUniforms;
 

--- a/js/render/nodes/stats-viewer-gpu.js
+++ b/js/render/nodes/stats-viewer-gpu.js
@@ -35,12 +35,9 @@ const STATS_WGSL = `
 struct FrameUniforms {
   projectionMatrix: mat4x4f,
   viewMatrix: mat4x4f,
-  lightDirection: vec3f,
-  _pad0: f32,
-  lightColor: vec3f,
-  _pad1: f32,
   cameraPosition: vec3f,
-  _pad2: f32,
+  lightDirection: vec3f,
+  lightColor: vec3f,
 };
 @group(0) @binding(0) var<uniform> frame: FrameUniforms;
 

--- a/webgpu/input-selection-benchmark.html
+++ b/webgpu/input-selection-benchmark.html
@@ -991,6 +991,42 @@ fn main(@builtin(global_invocation_id) globalId: vec3u) {
         }
       }
 
+      function shouldRenderControllerMesh(inputSource) {
+        return inputSource.targetRayMode == 'tracked-pointer';
+      }
+
+      function getControllerMeshKey(inputSource) {
+        return inputSource.profiles[0] + '_' + inputSource.handedness;
+      }
+
+      function addControllerMesh(key, assetPath) {
+        if (controllers[key] || !scene) {
+          return;
+        }
+
+        let controllerNode = new Gltf2GPUNode({url: assetPath});
+        setNodeTreeVisible(controllerNode, false);
+        controllers[key] = controllerNode;
+        scene.addNode(controllerNode);
+      }
+
+      function loadControllerMesh(inputSource) {
+        if (!shouldRenderControllerMesh(inputSource)) {
+          return;
+        }
+
+        const key = getControllerMeshKey(inputSource);
+        fetchProfile(inputSource, DEFAULT_PROFILES_PATH).then(({assetPath}) => {
+          addControllerMesh(key, assetPath);
+        });
+      }
+
+      function loadControllerMeshes(session) {
+        for (let inputSource of session.inputSources) {
+          loadControllerMesh(inputSource);
+        }
+      }
+
       function clearPreviousMatrices() {
         for (let key of Object.keys(previousMatrices)) {
           delete previousMatrices[key];
@@ -1948,17 +1984,7 @@ fn main(@builtin(global_invocation_id) globalId: vec3u) {
 
           session.addEventListener('inputsourceschange', (event) => {
             for (let inputSource of event.added) {
-              if (inputSource.targetRayMode == 'tracked-pointer') {
-                fetchProfile(inputSource, DEFAULT_PROFILES_PATH).then(({profile, assetPath}) => {
-                  let key = inputSource.profiles[0] + '_' + inputSource.handedness;
-                  if (!controllers[key] && scene) {
-                    let controllerNode = new Gltf2GPUNode({url: assetPath});
-                    setNodeTreeVisible(controllerNode, false);
-                    controllers[key] = controllerNode;
-                    scene.addNode(controllerNode);
-                  }
-                });
-              }
+              loadControllerMesh(inputSource);
             }
           });
         }
@@ -1981,6 +2007,9 @@ fn main(@builtin(global_invocation_id) globalId: vec3u) {
 
         configureCanvas(colorFormat);
         createRendererAndScene(colorFormat);
+        if (!benchmarkSession) {
+          loadControllerMeshes(session);
+        }
 
         updateFeatureControls();
 
@@ -2150,10 +2179,10 @@ fn main(@builtin(global_invocation_id) globalId: vec3u) {
         }
 
         for (let inputSource of frame.session.inputSources) {
-          if (inputSource.gripSpace) {
+          if (shouldRenderControllerMesh(inputSource) && inputSource.gripSpace) {
             let gripPose = frame.getPose(inputSource.gripSpace, xrRefSpace);
             if (gripPose) {
-              let key = inputSource.profiles[0] + '_' + inputSource.handedness;
+              let key = getControllerMeshKey(inputSource);
               if (controllers[key]) {
                 controllers[key].matrix = gripPose.transform.matrix;
                 setNodeTreeVisible(controllers[key], true);

--- a/webgpu/input-selection-benchmark.html
+++ b/webgpu/input-selection-benchmark.html
@@ -53,6 +53,7 @@ SOFTWARE.
         </p>
         <p id="webgpu_status"></p>
         <label><input type="checkbox" id="use_space_warp">space warp</label>
+        <label><input type="checkbox" id="use_multiview" disabled>multiview</label>
         <label><input type="checkbox" id="do_antialias" checked>MSAA</label>
         <label><input type="checkbox" id="use_ripple" checked>ripple</label>
         <div>
@@ -71,7 +72,14 @@ SOFTWARE.
       // This sample is an AI-assisted port of the equivalent WebGL sample, and may not represent WebGPU best practices.
       import {WebXRButton} from '../js/util/webxr-button.js';
       import {GPUScene, WebXRGPUView} from '../js/render/scenes/scene-gpu.js';
-      import {GPURenderer, RenderView, createWebGPUContext} from '../js/render/core/renderer-gpu.js';
+      import {
+        GPURenderer,
+        MULTISAMPLED_ARRAY_TEXTURE_FEATURES,
+        RenderView,
+        VIEW_INSTANCING_FEATURES,
+        createWebGPUContext,
+        getSupportedGPUFeature,
+      } from '../js/render/core/renderer-gpu.js';
       import {Node} from '../js/render/core/node.js';
       import {Gltf2GPUNode} from '../js/render/nodes/gltf2-gpu.js';
       import {Primitive, PrimitiveAttribute} from '../js/render/core/primitive.js';
@@ -414,6 +422,7 @@ fn main(@builtin(global_invocation_id) globalId: vec3u) {
       let webgpuStatus = document.getElementById('webgpu_status');
       let webgpuCanvas = document.getElementById('webgpu_canvas');
       let useSpaceWarp = document.getElementById('use_space_warp');
+      let useMultiview = document.getElementById('use_multiview');
       let doAntialias = document.getElementById('do_antialias');
       let useRipple = document.getElementById('use_ripple');
       let shapeCountControl = document.getElementById('shape_count');
@@ -427,7 +436,13 @@ fn main(@builtin(global_invocation_id) globalId: vec3u) {
       let immersiveVrSupported = false;
       let spaceWarpRequested = false;
       let spaceWarpEnabled = false;
+      let viewInstancingRequested = false;
+      let viewInstancingEnabled = false;
       let identityDeltaPose = null;
+      let webgpuCapabilities = {
+        viewInstancing: null,
+        multisampledArrayTextures: null,
+      };
 
       // This WebGPU code is an AI-assisted port of the equivalent WebGL sample,
       // and may not represent WebGPU best practices.
@@ -1693,8 +1708,13 @@ fn main(@builtin(global_invocation_id) globalId: vec3u) {
 
       function createRendererAndScene(colorFormat) {
         clearPreviousMatrices();
+        const enableViewInstancing =
+            viewInstancingEnabled && canUseViewInstancing();
         renderer = new GPURenderer(device, colorFormat, {
           sampleCount: doAntialias.checked ? 4 : 1,
+          viewInstancing: enableViewInstancing,
+          viewInstancingWgslEnable:
+              webgpuCapabilities.viewInstancing?.wgslEnable,
         });
         const sceneState = createSelectionScene(renderer);
         scene = sceneState.scene;
@@ -1721,6 +1741,19 @@ fn main(@builtin(global_invocation_id) globalId: vec3u) {
         lasers = [];
         activeLasers = 0;
         syncShapeCount();
+      }
+
+      function canUseViewInstancing() {
+        if (!device ||
+            !webgpuCapabilities.viewInstancing ||
+            !webgpuCapabilities.multisampledArrayTextures) {
+          return false;
+        }
+
+        const maxViewCount = 'maxViewInstanceCount' in device.limits ?
+            device.limits.maxViewInstanceCount :
+            2;
+        return maxViewCount >= 2;
       }
 
       function configureCanvas(format) {
@@ -1815,6 +1848,18 @@ fn main(@builtin(global_invocation_id) globalId: vec3u) {
         return xrColorDepthTexture.createView(depthViewDesc);
       }
 
+      function projectionLayerUsesDepthValues() {
+        return !binding || binding.usesDepthValues !== false;
+      }
+
+      function colorPassUsesAppDepth() {
+        return !spaceWarpEnabled && !projectionLayerUsesDepthValues();
+      }
+
+      function colorPassUsesLayerDepth() {
+        return !spaceWarpEnabled && projectionLayerUsesDepthValues();
+      }
+
       function drawCanvasFrame() {
         if (!scene || !renderer || !canvasContext) {
           return;
@@ -1892,15 +1937,26 @@ fn main(@builtin(global_invocation_id) globalId: vec3u) {
             !!device &&
             !!navigator.xr &&
             'XRGPUBinding' in window;
+        const canMultiview = canUseViewInstancing();
 
         if (webgpuStatus) {
           webgpuStatus.textContent = canEnter ?
-              'WebGPU XR support detected.' :
+              (canMultiview ?
+                'WebGPU XR support detected. Multiview support detected.' :
+                'WebGPU XR support detected.') :
               'WebGPU XR support was not detected.';
         }
 
         const sessionActive = !!(xrButton && xrButton.session);
         useSpaceWarp.disabled = !!benchmarkState || sessionActive;
+        useMultiview.disabled =
+            !!benchmarkState || sessionActive || !canMultiview;
+        if (!canMultiview) {
+          useMultiview.checked = false;
+        } else if (!useMultiview.dataset.initialized) {
+          useMultiview.checked = true;
+        }
+        useMultiview.dataset.initialized = 'true';
         doAntialias.disabled = !!benchmarkState || sessionActive;
         useRipple.disabled = !!benchmarkState || sessionActive;
         shapeCountControl.disabled = !!benchmarkState;
@@ -1917,11 +1973,23 @@ fn main(@builtin(global_invocation_id) globalId: vec3u) {
           return;
         }
 
-        device = await createWebGPUContext({xrCompatible: true});
+        device = await createWebGPUContext({
+          xrCompatible: true,
+          optionalFeatures: [
+            ...VIEW_INSTANCING_FEATURES.map(candidate => candidate.feature),
+            ...MULTISAMPLED_ARRAY_TEXTURE_FEATURES,
+          ],
+        });
         if (!device) {
           webgpuStatus.textContent = 'Failed to create a WebGPU device.';
           return;
         }
+        webgpuCapabilities.viewInstancing =
+            getSupportedGPUFeature(device.features, VIEW_INSTANCING_FEATURES);
+        webgpuCapabilities.multisampledArrayTextures =
+            getSupportedGPUFeature(
+                device.features,
+                MULTISAMPLED_ARRAY_TEXTURE_FEATURES);
 
         canvasFormat = navigator.gpu.getPreferredCanvasFormat();
         configureCanvas(canvasFormat);
@@ -1953,6 +2021,7 @@ fn main(@builtin(global_invocation_id) globalId: vec3u) {
 
       function onRequestSession() {
         spaceWarpRequested = useSpaceWarp.checked;
+        viewInstancingRequested = useMultiview.checked && canUseViewInstancing();
         const requiredFeatures = ['local-floor', 'webgpu'];
         if (spaceWarpRequested) {
           requiredFeatures.push('space-warp');
@@ -1966,6 +2035,7 @@ fn main(@builtin(global_invocation_id) globalId: vec3u) {
       function onSessionStarted(session) {
         xrButton.setSession(session);
         spaceWarpEnabled = spaceWarpRequested;
+        viewInstancingEnabled = viewInstancingRequested && canUseViewInstancing();
         const benchmarkSession = !!benchmarkState;
         if (benchmarkSession) {
           benchmarkState.session = session;
@@ -1995,10 +2065,12 @@ fn main(@builtin(global_invocation_id) globalId: vec3u) {
 
         const layerInit = {
           colorFormat: colorFormat,
-          depthStencilFormat: 'depth24plus',
           clearOnAccess: false,
         };
-        if (spaceWarpEnabled) {
+        if (spaceWarpEnabled || projectionLayerUsesDepthValues()) {
+          layerInit.depthStencilFormat = 'depth24plus';
+        }
+        if (spaceWarpEnabled || viewInstancingEnabled) {
           layerInit.textureType = 'texture-array';
         }
         layer = binding.createProjectionLayer(layerInit);
@@ -2031,6 +2103,8 @@ fn main(@builtin(global_invocation_id) globalId: vec3u) {
         binding = null;
         layer = null;
         spaceWarpEnabled = false;
+        viewInstancingRequested = false;
+        viewInstancingEnabled = false;
         identityDeltaPose = null;
         if (xrColorDepthTexture) {
           xrColorDepthTexture.destroy();
@@ -2328,8 +2402,50 @@ fn main(@builtin(global_invocation_id) globalId: vec3u) {
         }
       }
 
+      function createTextureArrayView(texture, viewCount) {
+        return texture.createView({
+          dimension: '2d-array',
+          baseArrayLayer: 0,
+          arrayLayerCount: viewCount,
+        });
+      }
+
       function drawXRFrame(frame, pose) {
         if (!pose || !scene) {
+          return;
+        }
+
+        if (viewInstancingEnabled && pose.views.length > 0) {
+          const viewCount = Math.min(pose.views.length, 2);
+          const subImage = binding.getViewSubImage(layer, pose.views[0]);
+          const viewDesc = {
+            dimension: '2d-array',
+            baseArrayLayer: 0,
+            arrayLayerCount: viewCount,
+          };
+          const colorView = createTextureArrayView(
+              subImage.colorTexture,
+              viewCount);
+          let depthView = null;
+          if (colorPassUsesAppDepth()) {
+            depthView = getXRColorDepthView(subImage, viewDesc);
+          } else if (colorPassUsesLayerDepth() && subImage.depthStencilTexture) {
+            depthView = createTextureArrayView(
+                subImage.depthStencilTexture,
+                viewCount);
+          }
+
+          let views = [];
+          for (let i = 0; i < viewCount; ++i) {
+            let renderView =
+                new WebXRGPUView(pose.views[i], subImage, colorView, depthView);
+            applyBenchmarkViewOverrides(frame, renderView);
+            views.push(renderView);
+          }
+
+          updateSpaceWarpDeltaPose();
+          scene.drawViewArray(views);
+          renderMotionAndDepth(frame, pose);
           return;
         }
 
@@ -2341,9 +2457,9 @@ fn main(@builtin(global_invocation_id) globalId: vec3u) {
 
           let colorView = subImage.colorTexture.createView(viewDesc);
           let depthView = null;
-          if (spaceWarpEnabled) {
+          if (colorPassUsesAppDepth()) {
             depthView = getXRColorDepthView(subImage, viewDesc);
-          } else if (subImage.depthStencilTexture) {
+          } else if (colorPassUsesLayerDepth() && subImage.depthStencilTexture) {
             depthView = subImage.depthStencilTexture.createView(viewDesc);
           }
 
@@ -2389,6 +2505,7 @@ fn main(@builtin(global_invocation_id) globalId: vec3u) {
 
       shapeCountControl.addEventListener('input', syncShapeCount);
       useSpaceWarp.addEventListener('change', updateFeatureControls);
+      useMultiview.addEventListener('change', updateFeatureControls);
       doAntialias.addEventListener('change', rebuildCanvasPreview);
       useRipple.addEventListener('change', rebuildCanvasPreview);
       benchmarkButton.addEventListener('click', startBenchmark);

--- a/webgpu/input-selection-benchmark.html
+++ b/webgpu/input-selection-benchmark.html
@@ -176,12 +176,9 @@ SOFTWARE.
 struct FrameUniforms {
   projectionMatrix: mat4x4f,
   viewMatrix: mat4x4f,
-  lightDirection: vec3f,
-  _pad0: f32,
-  lightColor: vec3f,
-  _pad1: f32,
   cameraPosition: vec3f,
-  _pad2: f32,
+  lightDirection: vec3f,
+  lightColor: vec3f,
 };
 @group(0) @binding(0) var<uniform> frame: FrameUniforms;
 
@@ -233,12 +230,9 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4f {
 struct FrameUniforms {
   projectionMatrix: mat4x4f,
   viewMatrix: mat4x4f,
-  lightDirection: vec3f,
-  _pad0: f32,
-  lightColor: vec3f,
-  _pad1: f32,
   cameraPosition: vec3f,
-  _pad2: f32,
+  lightDirection: vec3f,
+  lightColor: vec3f,
 };
 @group(0) @binding(0) var<uniform> frame: FrameUniforms;
 

--- a/webgpu/input-selection.html
+++ b/webgpu/input-selection.html
@@ -243,6 +243,42 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4f {
       let lasers = [];
       let activeLasers = 0;
 
+      function shouldRenderControllerMesh(inputSource) {
+        return inputSource.targetRayMode == 'tracked-pointer';
+      }
+
+      function getControllerMeshKey(inputSource) {
+        return inputSource.profiles[0] + '_' + inputSource.handedness;
+      }
+
+      function addControllerMesh(key, assetPath) {
+        if (controllers[key]) {
+          return;
+        }
+
+        let controllerNode = new Gltf2GPUNode({url: assetPath});
+        controllerNode.visible = false;
+        controllers[key] = controllerNode;
+        scene.addNode(controllerNode);
+      }
+
+      function loadControllerMesh(inputSource) {
+        if (!shouldRenderControllerMesh(inputSource)) {
+          return;
+        }
+
+        const key = getControllerMeshKey(inputSource);
+        fetchProfile(inputSource, DEFAULT_PROFILES_PATH).then(({assetPath}) => {
+          addControllerMesh(key, assetPath);
+        });
+      }
+
+      function loadControllerMeshes(session) {
+        for (let inputSource of session.inputSources) {
+          loadControllerMesh(inputSource);
+        }
+      }
+
       async function initXR() {
         if (!navigator.gpu) {
           console.error('WebGPU is not supported.');
@@ -311,17 +347,7 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4f {
         // Load controller models when input sources are connected.
         session.addEventListener('inputsourceschange', (event) => {
           for (let inputSource of event.added) {
-            if (inputSource.targetRayMode == 'tracked-pointer') {
-              fetchProfile(inputSource, DEFAULT_PROFILES_PATH).then(({profile, assetPath}) => {
-                let key = inputSource.profiles[0] + '_' + inputSource.handedness;
-                if (!controllers[key]) {
-                  let controllerNode = new Gltf2GPUNode({url: assetPath});
-                  controllerNode.visible = false;
-                  controllers[key] = controllerNode;
-                  scene.addNode(controllerNode);
-                }
-              });
-            }
+            loadControllerMesh(inputSource);
           }
         });
 
@@ -339,6 +365,7 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4f {
 
         renderer = new GPURenderer(device, colorFormat);
         scene.setRenderer(renderer);
+        loadControllerMeshes(session);
 
         // Create the box primitive and add boxes to the scene.
         let boxPrimitive = createBoxPrimitive();
@@ -484,10 +511,10 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4f {
         // Update controllers, lasers, and check if we can move grabbed objects.
         for (let inputSource of frame.session.inputSources) {
           // Position the controller model.
-          if (inputSource.gripSpace) {
+          if (shouldRenderControllerMesh(inputSource) && inputSource.gripSpace) {
             let gripPose = frame.getPose(inputSource.gripSpace, xrRefSpace);
             if (gripPose) {
-              let key = inputSource.profiles[0] + '_' + inputSource.handedness;
+              let key = getControllerMeshKey(inputSource);
               if (controllers[key]) {
                 controllers[key].matrix = gripPose.transform.matrix;
                 controllers[key].visible = true;

--- a/webgpu/input-selection.html
+++ b/webgpu/input-selection.html
@@ -93,12 +93,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 struct FrameUniforms {
   projectionMatrix: mat4x4f,
   viewMatrix: mat4x4f,
-  lightDirection: vec3f,
-  _pad0: f32,
-  lightColor: vec3f,
-  _pad1: f32,
   cameraPosition: vec3f,
-  _pad2: f32,
+  lightDirection: vec3f,
+  lightColor: vec3f,
 };
 @group(0) @binding(0) var<uniform> frame: FrameUniforms;
 


### PR DESCRIPTION
This updates the WebGPU input-selection samples and benchmark to better match the WebGL benchmark path and exercise newer XR/WebGPU rendering features.

Changes:
- Fix WebGPU controller/hand model rendering by using the normal profile mesh loading path and honoring glTF vertex layouts.
- Add a multiview/view-instancing option to `webgpu/input-selection-benchmark.html` when the required WebGPU features are available.
- Add renderer support for WebGPU view instancing and multisampled texture-array attachments.
- Avoid using projection-layer depth for the color pass when depth is not consumed or when space warp only needs depth from the motion pass.
- Optimize the view-instanced shader path by precomputing per-view view-projection matrices.